### PR TITLE
Adds published tag as duplicate of updated for old rss clients.

### DIFF
--- a/main.tmpl
+++ b/main.tmpl
@@ -129,6 +129,7 @@
         #   "#" & %postId
         <link rel="alternate" type="text/html"
           href="${c.req.makeUri(url)}"/>
+        <published>${%threadDate}</published>
         <updated>${%threadDate}</updated>
         <author><name>${XMLEncode(%postAuthor)}</name></author>
         <content type="html"
@@ -177,6 +178,7 @@ ${XMLEncode(rstToHtml(%postContent))}</content>
         #   "#" & %postId
         <link rel="alternate" type="text/html"
           href="${c.req.makeUri(url)}"/>
+        <published>${%postRssDate}</published>
         <updated>${%postRssDate}</updated>
         <author><name>${XMLEncode(%postAuthor)}</name></author>
         <content type="html"


### PR DESCRIPTION
The duplication of the date value in the thread activity rss may not be entirely correct, as it may have more sense to have the publication date as the first post's creation date and the modification date as the last post's modification date, but I didn't want to add more sql overhead due to performance concerns (see #21).
