### PR TITLE
highlighting current post via CSS :hover pseudo-element

### DIFF
--- a/forms.tmpl
+++ b/forms.tmpl
@@ -123,7 +123,7 @@
 #  for row in posts:
 #    inc(count)
   <a name="${%postId}"></a>
-  <div>
+  <div id="${%postId}">
     <div class="author">
       <div>
         #let profileUrl = c.req.makeUri("profile/", false) & xmlEncode(%userName)

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -512,8 +512,8 @@ hr
 
 /* highlighting current post */
 
-.post.current {
-	background-color: #fefff3;
+div:target {
+  background: rgba(255, 255, 240, 0.25) !important;
 }
 
 /* full-text search */


### PR DESCRIPTION
Highlights current post without `postId` URL-parameter, via URL-fragment ("#"-part).
