### PR TITLE
Added username search, reworked fts.sql,  fixed links from search results

### DIFF
--- a/black_list.txt
+++ b/black_list.txt
@@ -1,0 +1,1 @@
+fifa coin*

--- a/by_author.sql
+++ b/by_author.sql
@@ -1,0 +1,18 @@
+SELECT
+        thread.id AS thread_id,
+        thread.name AS thread,
+        post.id AS post_id,
+        post.header AS header,
+        SUBSTR(post.content, 1, 200) AS content,
+        person.name AS author,
+        post.creation AS cdate,
+        post.author AS author_id,
+        person.email AS email,
+        CASE SUBSTR(post.header,1,3) WHEN 'Re:' THEN 2 ELSE 1 END AS what
+FROM post   JOIN thread ON post.thread == thread.id
+            JOIN person ON post.author == person.id
+WHERE
+        person.id == ?
+ORDER BY cdate DESC
+LIMIT ? OFFSET (? - 1) * ?
+;

--- a/forms.tmpl
+++ b/forms.tmpl
@@ -285,7 +285,8 @@
 #
 #proc genSearchResults(c: var TForumData,
 #                       results: iterator: db_sqlite.TRow {.closure, tags: [FReadDB].},
-#                       count: var int): string =
+#                       count: var int,
+#                       getPostsPage: proc(post, thread: int): string): string =
 #  const threadId = 0
 #  const threadName = 1
 #  const postId = 2
@@ -311,7 +312,7 @@
 #    inc(count)
 #    let isThread = %what == "0"
 #    inc(whCount[isThread])
-#    let postUrl = c.genThreadUrl(%postId,"",%threadId,"")
+#    let postUrl = c.genThreadUrl(%postId,"",%threadId,getPostsPage(parseInt(%postId),parseInt(%threadId)))
 #    let threadUrl = c.genThreadUrl("","",%threadId)
 #    var headersDiffer = false
   <div>

--- a/fts.sql
+++ b/fts.sql
@@ -1,40 +1,3 @@
--- selects just threads,
--- those where title doesn't coinside with some of its posts' titles
--- by now selects only the threads title (no post snippet)
-SELECT
-        thread_id,
-        snippet(thread_fts, '<b>', '</b>', '<b>...</b>') AS thread,
-        0 AS post_id,
-        '' AS header,
-        '' AS content,
-        person.name AS author,
-        cdate,
-        author_id,
-        person.email AS email,
-        0 AS what
-    FROM (
-        SELECT
-                thread_fts.id AS thread_id,
-                post.id AS post_id,
-                post.creation AS cdate,
-                MIN(post.creation) AS cdate,
-                post.author AS author_id
-            FROM thread_fts
-            JOIN post ON post.thread=thread_id
-            WHERE thread_fts MATCH ?
-            GROUP BY thread_id, post_id
-            HAVING thread_id NOT IN (
-                SELECT thread
-                    FROM post_fts JOIN post USING(id)
-                    WHERE post_fts MATCH ?
-            )
-            LIMIT ? OFFSET (? - 1) * ?
-    )
-        JOIN thread_fts ON thread_fts.id=thread_id
-        JOIN person ON person.id=author_id
-    WHERE thread_fts MATCH ?
-UNION
--- the main query, selects posts
 SELECT
         thread.id AS thread_id,
         thread.name AS thread,
@@ -53,22 +16,38 @@ SELECT
     FROM post_fts JOIN (
     -- inner query, selects ids of matching posts, orders and limits them,
     -- so snippets only for limited count of posts are created (in outer query)
-        SELECT id, post.creation AS cdate, thread, 1 AS what, post.author AS author
-            FROM post_fts JOIN post USING(id)
-            WHERE post_fts.header MATCH ?
-            GROUP BY post.header
-            HAVING SUBSTR(post.header,1,3)<>'Re:'
-        UNION
-        SELECT id, post.creation AS cdate, thread, 2 AS what, post.author AS author
-            FROM post_fts JOIN post USING(id)
-            WHERE post_fts.content MATCH ?
+        SELECT * FROM (         -- a wrapper query to be able make GROUP BY
+            SELECT id, post.creation AS cdate, thread, 1 AS what, post.author AS author
+                FROM post_fts JOIN post USING(id)
+                WHERE post_fts.header MATCH ?           -- query-w/o-author
+                GROUP BY post.header
+                HAVING SUBSTR(post.header,1,3)<>'Re:'
+                    AND (? == 0 OR post.author == ?)    -- author, author
+            UNION
+            SELECT id, post.creation AS cdate, thread, 1 AS what, post.author AS author
+                FROM post_fts JOIN post USING(id)
+                WHERE post_fts.header MATCH ?           -- query
+                GROUP BY post.header
+                HAVING SUBSTR(post.header,1,3)<>'Re:'
+            UNION
+            SELECT id, post.creation AS cdate, thread, 2 AS what, post.author AS author
+                FROM post_fts JOIN post USING(id)
+                WHERE post_fts.content MATCH ?          -- query-w/o-author
+                GROUP BY post_fts.id
+                HAVING (? == 0 OR post.author == ?)     -- author, author
+            UNION
+            SELECT id, post.creation AS cdate, thread, 2 AS what, post.author AS author
+                FROM post_fts JOIN post USING(id)
+                WHERE post_fts.content MATCH ?          -- query
+        )
+        GROUP BY id
         ORDER BY what, cdate DESC
-        LIMIT ? OFFSET (? - 1) * ?
+        LIMIT ? OFFSET (? - 1) * ?                      -- threads-per-page, pageNum, threads-per-page
     ) AS post USING(id)
         JOIN thread ON thread.id=thread
         JOIN person ON person.id=author
-    WHERE post_fts MATCH ?
-ORDER BY what ASC, cdate DESC
+    WHERE post_fts MATCH ?                              -- query
+ORDER BY cdate DESC
 LIMIT 300 -- hardcoded limit just in case
 ;
 

--- a/static/search-help.rst
+++ b/static/search-help.rst
@@ -1,9 +1,6 @@
 Full-text search for Nim forum
 ==============================
 
-Syntax (using *SQLite* dll compiled without *Enhanced Query Syntax* support):
------------------------------------------------------------------------------
-
 - Only alphanumeric characters are searched.
 - Only full words and words beginnings (e.g. ``Nim*`` for both ``Nimrod`` and ``Nim``) are searched
 - All words are joined with implicit **AND** operator; there's no explicit one
@@ -13,23 +10,25 @@ Syntax (using *SQLite* dll compiled without *Enhanced Query Syntax* support):
 - Quotes for phrases search, e.g. ``"programming language"``
 - Distances between words/phrases can be specified putting ``NEAR`` or ``NEAR/some_number`` between them
 
-Syntax - differences in *Enhanced Query Syntax* (should be enabled in *SQLite* dll):
-------------------------------------------------------------------------------------
-
-- **AND** and **NOT** logical operators available
-- Precedence of operators is, from highest to lowest: **NOT**, **AND**, **OR**
-- Parentheses for grouping are supported
-
 Where search is performed:
 --------------------------
 
-- **Threads' titles** - these results are outputed first
-- **Posts' titles** - middle precedence
-- **Posts' contents** - the latest
+- **Threads' titles**
+- **Posts' contents**
+- **User names**
 
 How results are shown:
 ----------------------
 
 - All results are ordered by date (posts' edits don't affect)
-- Matched tokens in text are marked (bold or dotted underline)
-- Threads title is the link to the thread and posts title is the link to the post
+- Matched tokens in text are marked (bold or underline)
+- Posts title is the link to the post
+
+Username search:
+-----------------
+
+The first and the last words of the search are checked to being a username of an existing user. If so, then additionally posts/threads of that user are searched with the query without the username.
+
+E.g.: Considering there exists a user *User1*, *"User1 macro"* searches for *User1*'s posts containing word *"macro"* and any user's posts containing simultaneously both words *"User1"* and *"macro"*.
+
+To search for all threads and posts of some user, enter just username.


### PR DESCRIPTION
- Search results can be narrowed to some users posts by prepending or appending the username to the query
- List of all threads and posts of user can be obtained by supplying just his username as a search query
- ``fts.sql`` is simplified due to removing unused functionality (search in both thread and post titles)
- Links to posts led always to the 1st page of the respective  thread (IIRC because of ``"/" & postId`` was declined from ``genThreadUrl``); now the page number is calculated.