### PR TITLE
Changed config file to use $lib and different syntax

### DIFF
--- a/forum.nim.cfg
+++ b/forum.nim.cfg
@@ -1,5 +1,3 @@
 
 # we need the documentation generator of the compiler:
---path:"$nimrod/lib/packages/docutils"
-
---path:"$nimrod"
+path="$lib/packages/docutils"


### PR DESCRIPTION
I had a problem compiling nimforum because it didn't find the
docutils/rst which boiled down to not add the right path for them in the
config file. I changed the syntax to be the same as in /etc/nim.cfg and
it works for me. I am not sure if that works everywhere though.