### PR TITLE
Updated the config file

### DIFF
--- a/forum.nim.cfg
+++ b/forum.nim.cfg
@@ -1,5 +1,4 @@
 
 # we need the documentation generator of the compiler:
---path:"$nimrod/lib/packages/docutils"
-
---path:"$nimrod"
+path="$lib/packages/docutils"
+path="$nim"


### PR DESCRIPTION
I updated the config file to use the syntax of the nim.cfg file. The author of nimbcrypt also updated his repository. With those changes nimforum compiles out of the box on my system \o/