### PR TITLE
Updated css to show which forum links were visited

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -272,6 +272,7 @@ pre .EscapeSequence
       font-weight:bold; 
       white-space: nowrap;
     }
+    #talk-threads > div > .topic > div > a:visited { color: #1a1a1a; }
     #talk-threads > div > .detail > div { float:left; margin:0; }
     #talk-threads > div > .detail > div > div { margin-left:15px; padding: 5px 5px 5px 22px; }
     #talk-threads > div > .detail > div { width:50%; }


### PR DESCRIPTION
The color used: #1a1a1a, matches the color on the forum stats near the bottom (online, users, posts, etc...) which looks like this: http://i.imgur.com/awDGSND.png