### PR TITLE
Enforce DB content length limit

### DIFF
--- a/forum.nim
+++ b/forum.nim
@@ -462,6 +462,10 @@ template retrContent(c: expr) =
   let content {.inject.} = c.req.params["content"]
   if content.strip.len < 10:
     return setError(c, "content", "Content not long enough")
+  # Enforce DB content length for posts
+  elif content.len > 1000:
+    return setError(c, "content", "Post length too long")
+
   if not validateRst(c, content): return false
 
 template retrPost(c: expr) =


### PR DESCRIPTION
Content length limit of 1000 characters at DB level should be enforced
at the application level.

Fixes #9 for posts.