### PR TITLE
Make .tmpl files use stdtmpl | standard

### DIFF
--- a/forms.tmpl
+++ b/forms.tmpl
@@ -1,4 +1,4 @@
-#! stdtmpl
+#? stdtmpl | standard
 #
 #template `%`(idx: expr): expr {.immediate.} =
 #  row[idx]

--- a/main.tmpl
+++ b/main.tmpl
@@ -1,4 +1,4 @@
-#! stdtmpl
+#? stdtmpl | standard
 #proc genMain(c: var TForumData, content: string, title = "Nim Forum",
 #             additional_headers = "", showRssLinks = false): string =
 #  result = ""


### PR DESCRIPTION
Fixes #80 
Wouldn't compile on 0.13.1 with `#! stdtmpl`, would with
`#? stdtmpl | standard`