### PR TITLE
Allow to specify root HTML node for RST formatter

### DIFF
--- a/forum.nim
+++ b/forum.nim
@@ -467,7 +467,7 @@ proc rstToHtml(content: string): string =
   # TODO: Yes, this is ugly. I wrote it quickly. PRs welcome ;)
   try:
     var node = parseHtml(newStringStream(result))
-    var newNode = newElement("document")
+    var newNode = newElement("div")
     if node.kind == xnElement:
       var currentBlockquote = newElement("blockquote")
       for n in items(node):


### PR DESCRIPTION
It turns out that many RSS readers (or at least two I'm using:
http://feedly.com and http://twentyfivesquares.com/press/) do not handle
non-HTML tags in Atom content tag and skipping the whole content of
it. This patch allows to specify different (in this case `<div>`) node to
make readers happy.