### PR TITLE
Update Gravatar URL to use HTTPS

### DIFF
--- a/forum.nim
+++ b/forum.nim
@@ -202,7 +202,7 @@ proc formatTimestamp(t: int): string =
 
 proc getGravatarUrl(email: string, size = 80): string =
   let emailMD5 = email.toLowerAscii.toMD5
-  return ("http://www.gravatar.com/avatar/" & $emailMD5 & "?s=" & $size &
+  return ("https://www.gravatar.com/avatar/" & $emailMD5 & "?s=" & $size &
      "&d=identicon")
 
 proc genGravatar(email: string, size: int = 80): string =


### PR DESCRIPTION
Gravatars are currently loaded over HTTP, causing mixed content forums. Changing to HTTPS is a trivial change that makes sense in my opinion.