### PR TITLE
Fix compilation error: Move addr, port to connect in smtp

### DIFF
--- a/utils.nim
+++ b/utils.nim
@@ -110,8 +110,8 @@ proc sendMail(config: Config, subject, message, recipient: string, from_addr = "
     echo("[WARNING] Cannot send mail: no smtp server configured (smtpAddress).")
     return
 
-  var client = newAsyncSmtp(config.smtpAddress, Port(config.smtpPort))
-  await client.connect()
+  var client = newAsyncSmtp()
+  await client.connect(config.smtpAddress, Port(config.smtpPort))
   if config.smtpUser.len > 0:
     await client.auth(config.smtpUser, config.smtpPassword)
 


### PR DESCRIPTION
Following https://github.com/nim-lang/Nim/commit/fecad72e02256c947e1c16cd003ceca62a3633e5 `forum.nim` didn't compile with devel: 
```
utils.nim(108, 144) template/generic instantiation from here 
utils.nim(113, 28) Error: type mismatch: got (string, Port) but expected one of:
  proc newAsyncSmtp(useSsl = false; debug = false; sslContext = defaultSslContext): AsyncSmtp
```
This moves address and port from `newAsyncSmtp` to `connect`.