### PR TITLE
Remove cairo from .nimble deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ changing the dependencies slightly.
 
 ```
 [Deps]
-Requires: "nim >= 0.14.0, jester#head, bcrypt#head, recaptcha >= 1.0.0"
+Requires: "nim >= 0.14.0, jester#head, bcrypt >= 0.2.1, recaptcha >= 1.0.0"
 ```
 
 # Running the forum

--- a/README.md
+++ b/README.md
@@ -15,23 +15,8 @@ _See also: Running the forum for how to create the database_
 ## Dependencies
 
 The code depends on the RST parser of the Nim
-compiler and on Jester. The code generating captchas for registration uses the
-[cairo module](https://github.com/nim-lang/cairo), which requires you to have
-the [cairo library](http://cairographics.org) installed when you run the forum,
-or you will be greeted by a cryptic error message similar to:
-
-	$ ./forum could not load: libcairo.so(1.2)
-
-### Mac OS X
-
-#### cairo
-If you are using macosx and have installed the ``cairo`` library through
-[MacPorts](https://www.macports.org) you still need to add the library path to
-your ``LD_LIBRARY_PATH`` environment variable. Example:
-
-	$ LD_LIBRARY_PATH=/opt/local/lib/ ./forum
-
-Replace ``/opt/local/lib`` with the correct path on your system.
+compiler and on Jester. The captchas for registration uses the
+[reCaptcha module](https://github.com/euantorano/recaptcha.nim).
 
 #### bcrypt
 
@@ -47,7 +32,7 @@ changing the dependencies slightly.
 
 ```
 [Deps]
-Requires: "nimrod >= 0.10.3, cairo#head, jester#head, bcrypt >= 0.2.1"
+Requires: "nim >= 0.14.0, jester#head, bcrypt#head, recaptcha >= 1.0.0"
 ```
 
 # Running the forum
@@ -69,12 +54,12 @@ After that you can just run `forum` and if everything is ok you will get the inf
 
 _There is an update helper `editdb` which you can safely ignore for now._
 
-_The files `captchas.nim`, `cache.nim` are included by `forum.nim` and do
+_The file `cache.nim` is included by `forum.nim` and do
 not need to be compiled by you._
 
 # Copyright
 
-Copyright (c) 2012-2015 Andreas Rumpf, Dominik Picheta.
+Copyright (c) 2012-2017 Andreas Rumpf, Dominik Picheta.
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,18 @@ This is Nim's forum. Available at http://forum.nim-lang.org.
 
 ## Building
 
-You can use ``nimble`` (available [here](https://github.com/nim-lang/nimble)
+You can use ``nimble`` (available [here](https://github.com/nim-lang/nimble))
 to get all the necessary
 [dependencies](https://github.com/nim-lang/nimforum/blob/master/nimforum.nimble#L11).
 
 Clone this repo and execute ``nimble build`` in this repositories directory.
 
-_See also: Running the forum for how to create the database_
+See also: <a href="#running-the-forum">Running the forum</a> for how to create the database.
 
 ## Dependencies
 
-The code depends on the RST parser of the Nim
-compiler and on Jester. The captchas for registration uses the
-[reCaptcha module](https://github.com/euantorano/recaptcha.nim).
+The code depends on the RST parser of the Nim compiler and on Jester.  
+The captchas for registration uses the [reCaptcha module](https://github.com/euantorano/recaptcha.nim).
 
 #### bcrypt
 

--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -8,4 +8,4 @@ license       = "MIT"
 bin = "forum"
 
 [Deps]
-Requires: "nim >= 0.14.0, cairo#head, jester#head, bcrypt#head, recaptcha >= 1.0.0"
+Requires: "nim >= 0.14.0, jester#head, bcrypt#head, recaptcha >= 1.0.0"


### PR DESCRIPTION
Removed `cairo` from `nimforum.nimble` and from the readme.