### PR TITLE
Use rst.txt as help file - Fix #102

### DIFF
--- a/forms.tmpl
+++ b/forms.tmpl
@@ -443,7 +443,7 @@
 <div id="markhelp">
     <p>nimforum uses a slightly-customized version of
         <a href="http://www.sphinx-doc.org/en/stable/rest.html">reStructuredText</a> for formatting. See below for some basics, or check
-        <a href="http://forum.nim-lang.org/rst">this link</a> for a more detailed help reference.</p>
+        <a href="/rst">this link</a> for a more detailed help reference.</p>
     <table class="rst">
         <tbody>
             <tr class="markheading">

--- a/forms.tmpl
+++ b/forms.tmpl
@@ -443,7 +443,7 @@
 <div id="markhelp">
     <p>nimforum uses a slightly-customized version of
         <a href="http://www.sphinx-doc.org/en/stable/rest.html">reStructuredText</a> for formatting. See below for some basics, or check
-        <a href="http://nim-lang.org/rst.html">this link</a> for a more detailed help reference.</p>
+        <a href="http://forum.nim-lang.org/rst">this link</a> for a more detailed help reference.</p>
     <table class="rst">
         <tbody>
             <tr class="markheading">

--- a/forum.nim
+++ b/forum.nim
@@ -1346,6 +1346,8 @@ routes:
     resp genMain(c, page)
   get "/search-help":
     textPage "static/search-help"
+  get "/rst":
+    textPage "static/rst"
 
 when isMainModule:
   randomize()

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9,7 +9,19 @@ body {
     font: 13pt Helvetica,Arial,sans-serif;
     background:#152534 url("/images/bg.png") no-repeat fixed center top; }
 
-pre { color: #F5F5F5;}
+pre {
+  color: #F5F5F5;
+  overflow:auto;
+  margin:0;
+  padding:15px 10px;
+  font-size:10pt;
+  font-style:normal;
+  line-height:14pt;
+  background:rgba(0,0,0,.75);
+  border-left:8px solid rgba(0,0,0,.3);
+  margin-bottom: 10pt;
+  font-family: "DejaVu Sans Mono", monospace;
+}
 pre, pre * { cursor:text; }
 pre .Comment { color:#6D6D6D; font-style:italic; }
 pre .Keyword { color:#43A8CF; font-weight:bold; }

--- a/static/rst.rst
+++ b/static/rst.rst
@@ -1,5 +1,4 @@
-===========================================================================
-       reStructuredText cheat sheet
+reStructuredText cheat sheet
 ===========================================================================
 
 This is a cheat sheet for the *reStructuredText* dialect as implemented by
@@ -14,7 +13,7 @@ Elements of **markdown** are also supported.
 
 
 Inline elements
-===============
+---------------
 
 Ordinary text may contain *inline elements*:
 
@@ -30,20 +29,20 @@ Plain text                        Result
 ===============================   ============================================
 
 Links
-=====
+-----
 
-Links are either direct URLs like ``http://nim-lang.org`` or written like
+Links are either direct URLs like ``https://nim-lang.org`` or written like
 this::
   
-  `Nim <http://nim-lang.org>`_
+  `Nim <https://nim-lang.org>`_
   
 Or like this::
 
-  `<http://nim-lang.org>`_
+  `<https://nim-lang.org>`_
 
 
 Code blocks
-===========
+-----------
 
 are done this way::
 
@@ -81,7 +80,7 @@ Is rendered as:
 
 
 Literal blocks
-==============
+--------------
 
 Are introduced by '::' and a newline. The block is indicated by indentation: 
 
@@ -98,7 +97,7 @@ Is rendered as::
 
 
 Bullet lists
-============
+------------
 
 look like this::
 
@@ -123,7 +122,7 @@ Is rendered as:
 
 
 Enumerated lists
-================
+----------------
 
 are written like this::
 
@@ -143,7 +142,7 @@ Is rendered as:
 
 
 Quoting someone
-===============
+---------------
 
 quotes are just::
 
@@ -160,7 +159,7 @@ Is rendered as:
 
 
 Definition lists
-================
+----------------
 
 are written like this::
 
@@ -190,7 +189,7 @@ how
 
 
 Tables
-======
+------
 
 Only *simple tables* are supported. They are of the form::
 
@@ -218,3 +217,10 @@ Cell 4                  Cell 5; any           Cell 6
                         multiple lines
 Cell 7                  Cell 8                Cell 9
 ==================      ===============       ===================
+
+Images
+------
+
+```
+.. image:: path/to/img.png
+```

--- a/static/rst.rst
+++ b/static/rst.rst
@@ -3,7 +3,7 @@
 ===========================================================================
 
 This is a cheat sheet for the *reStructuredText* dialect as implemented by
-Nimrod's documentation generator which has been reused for this forum. :-)
+Nim's documentation generator which has been reused for this forum.
 
 See also the
 `official RST cheat sheet <http://docutils.sourceforge.net/docs/user/rst/cheatsheet.txt>`_ 
@@ -32,14 +32,14 @@ Plain text                        Result
 Links
 =====
 
-Links are either direct URLs like ``http://nimrod-lang.org`` or written like
+Links are either direct URLs like ``http://nim-lang.org`` or written like
 this::
   
-  `Nimrod <http://nimrod-lang.org>`_
+  `Nim <http://nim-lang.org>`_
   
 Or like this::
 
-  `<http://nimrod-lang.org>`_
+  `<http://nim-lang.org>`_
 
 
 Code blocks
@@ -47,7 +47,7 @@ Code blocks
 
 are done this way::
 
-  .. code-block:: nimrod
+  .. code-block:: nim
     
     if x == "abc":
       echo "xyz"
@@ -55,25 +55,25 @@ are done this way::
 
 Is rendered as:
 
-.. code-block:: nimrod
+.. code-block:: nim
   
   if x == "abc":
     echo "xyz"
 
 
-Except Nimrod, the programming languages C, C++, Java and C# have highlighting
+Except Nim, the programming languages C, C++, Java and C# have highlighting
 support.
 
 An alternative github-like syntax is also supported. This has the advantage
 that no excessive indentation is needed::
 
-  ```nimrod  
+  ```nim  
     if x == "abc":
       echo "xyz"```
 
 Is rendered as:
 
-.. code-block:: nimrod
+.. code-block:: nim
   
   if x == "abc":
     echo "xyz"


### PR DESCRIPTION
Reuse a rst help file that was already in the repo to generate an rst help page at `forum.nim-lang.org/rst` and link to it when posting a new comment/thread.
I needed to add css styling for generic `pre` elements, but I think it should be fine as the text was already white, this just adds the black background.
This closes #102 .