### PR TITLE
Make date a link to the post

### DIFF
--- a/forms.tmpl
+++ b/forms.tmpl
@@ -170,7 +170,7 @@
         #except EParseError:
         #  c.errorMsg = getCurrentExceptionMsg()
         #end
-        <span class="date">${xmlEncode(%postCreation)}</span>
+        <span class="date"><a href="${c.genThreadUrl(%postId, "", $threadId, $(c.pageNum))}">${xmlEncode(%postCreation)}</a></span>
       </div>
     </div>
   </div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -751,3 +751,9 @@ blockquote p {
 .failedComp {
   color: lightcoral;
 }
+.date > a, .date > a:hover, .date > a:visited {
+  color: #3D3D3D !important;
+}
+.date > a:hover {
+  text-decoration: none !important;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -753,7 +753,5 @@ blockquote p {
 }
 .date > a, .date > a:hover, .date > a:visited {
   color: #3D3D3D !important;
-}
-.date > a:hover {
   text-decoration: none !important;
 }


### PR DESCRIPTION
The date in a post now acts as a direct link to the post, with the format `<url>/t/threadId/page#postID`, eg `http://localhost:5000/t/2/1#13`.
No visual changes.

Closes #113 