### PR TITLE
Add better RST preview error

### DIFF
--- a/src/forum.nim
+++ b/src/forum.nim
@@ -1071,7 +1071,8 @@ routes:
     except EParseError:
       let err = PostError(
         errorFields: @[],
-        message: "Message needs to be valid RST!"
+        message: "Message needs to be valid RST! Error: " &
+                 getCurrentExceptionMsg()
       )
       resp Http400, $(%err), "application/json"
 

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -1071,7 +1071,7 @@ routes:
     except EParseError:
       let err = PostError(
         errorFields: @[],
-        message: getCurrentExceptionMsg()
+        message: "Message needs to be valid RST!"
       )
       resp Http400, $(%err), "application/json"
 


### PR DESCRIPTION
If the RST is invalid, we should tell the user instead of the current exception being shown.

Fixes #195 