### PR TITLE
Hide all the avatars but the first on small screens

### DIFF
--- a/public/css/nimforum.scss
+++ b/public/css/nimforum.scss
@@ -253,6 +253,13 @@ $threads-meta-color: #545d70;
 
 }
 
+// Hide all the avatars but the first on small screens.
+@media screen and (max-width: 600px) {
+  #threads-list a:not(:first-child) > .avatar {
+    display: none;
+  }
+}
+
 .posts, .about {
   @extend .grid-md;
   @extend .container;


### PR DESCRIPTION
Disclaimer, my {s,}css knowledge is shit but I tried anyway.
The idea is to do as discourse does and hide all but one circles in order not to waste precious screen space.