### PR TITLE
Better way of updating nginx configuration

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -100,7 +100,7 @@ You should then create a symlink to this file inside ``/etc/nginx/sites-enabled/
 ln -s /etc/nginx/sites-available/<forum.hostname.com> /etc/nginx/sites-enabled/<forum.hostname.com>
 ```
 
-Then restart nginx by running ``sudo systemctl restart nginx``.
+Then reload nginx configuration by running ``sudo nginx -s reload``.
 
 ### Supervisor
 


### PR DESCRIPTION
Using `nginx -s reload` is better than restarting the server on live systems, because if there is any problem with new config files, nginx will warn you, refuse to reload and continue to work with old configuration. Moreover, this command will minimize downtime.