### PR TITLE
Add category section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ createdb
 editdb
 
 .vscode
+forum.json*
+browsertester
+setup_nimforum
+buildcss
+nimforum.css
+
+/src/frontend/forum.js

--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -21,7 +21,7 @@ requires "sass#649e0701fa5c"
 
 requires "karax#f6bda9a"
 
-requires "webdriver#c2fee57"
+requires "webdriver#7091895"
 
 # Tasks
 
@@ -31,6 +31,9 @@ task backend, "Compiles and runs the forum backend":
 
 task runbackend, "Runs the forum backend":
   exec "./src/forum"
+
+task testbackend, "Runs the forum backend in test mode":
+  exec "nimble c -r -d:skipRateLimitCheck src/forum.nim"
 
 task frontend, "Builds the necessary JS frontend (with CSS)":
   exec "nimble c -r src/buildcss"

--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -21,7 +21,7 @@ requires "sass#649e0701fa5c"
 
 requires "karax#f6bda9a"
 
-requires "webdriver#7091895"
+requires "webdriver#429933a"
 
 # Tasks
 

--- a/public/css/nimforum.scss
+++ b/public/css/nimforum.scss
@@ -122,6 +122,19 @@ $logo-height: $navbar-height - 20px;
   }
 }
 
+.category-description {
+  opacity: 0.6;
+  font-size: small;
+}
+
+.category-status {
+  .topic-count {
+    margin-left: 5px;
+    opacity: 0.7;
+    font-size: small;
+  }
+}
+
 .category {
   white-space: nowrap;
 }

--- a/public/css/nimforum.scss
+++ b/public/css/nimforum.scss
@@ -22,6 +22,7 @@ table th {
 // Custom styles.
 // - Navigation bar.
 $navbar-height: 60px;
+$default-category-color: #98c766;
 $logo-height: $navbar-height - 20px;
 
 .navbar-button {
@@ -166,6 +167,33 @@ $logo-height: $navbar-height - 20px;
   }
 }
 
+.thread-list {
+  @extend .container;
+  @extend .grid-xl;
+}
+
+.category-list {
+  @extend .thread-list;
+
+
+  .category-title {
+    @extend .thread-title;
+    a, a:hover {
+      color: lighten($body-font-color, 10%);
+      text-decoration: none;
+    }
+  }
+
+  .category-description {
+    opacity: 0.6;
+  }
+}
+
+#categories-list .category {
+  border-left: 6px solid;
+  border-left-color: $default-category-color;
+}
+
 $super-popular-color: #f86713;
 $popular-color: darken($super-popular-color, 25%);
 $threads-meta-color: #545d70;
@@ -217,7 +245,7 @@ $threads-meta-color: #545d70;
 .category-color {
   width: 0;
   height: 0;
-  border: 0.3rem solid #98c766;
+  border: 0.3rem solid $default-category-color;
   display: inline-block;
   margin-right: 5px;
 }
@@ -725,9 +753,4 @@ hr {
   .footer {
     margin-top: $control-padding-y*2;
   }
-}
-
-// - Hide features that have not been implemented yet.
-#main-buttons > section.navbar-section:nth-child(1) {
-  display: none;
 }

--- a/src/buildcss.nim
+++ b/src/buildcss.nim
@@ -1,4 +1,4 @@
-import os, strutils
+import os
 
 import sass
 

--- a/src/email.nim
+++ b/src/email.nim
@@ -20,7 +20,7 @@ proc newMailer*(config: Config): Mailer =
 proc rateCheck(mailer: Mailer, address: string): bool =
   ## Returns true if we've emailed the address too much.
   let diff = getTime() - mailer.lastReset
-  if diff.hours >= 1:
+  if diff.inHours >= 1:
     mailer.lastReset = getTime()
     mailer.emailsSent.clear()
 

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -814,7 +814,6 @@ routes:
       countQuery = sql"select count(*) from thread;"
       countArgs: seq[string] = @[]
 
-
     if categoryId != -1:
       categorySection = "c.id == ? and "
       countQuery = sql"select count(*) from thread t, category c where category == c.id and c.id == ?;"

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -791,12 +791,18 @@ routes:
 
   get "/categories.json":
     # TODO: Limit this query in the case of many many categories
-    const categoriesQuery = sql"""select * from category;"""
+    const categoriesQuery =
+      sql"""
+        select c.*, count(thread.category)
+        from category c
+        left join thread on c.id == thread.category
+        group by c.id;
+      """
 
     var list = CategoryList(categories: @[])
     for data in getAllRows(db, categoriesQuery):
       let category = Category(
-        id: data[0].getInt, name: data[1], description: data[2], color: data[3]
+        id: data[0].getInt, name: data[1], description: data[2], color: data[3], numTopics: data[4].parseInt
       )
       list.categories.add(category)
 

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -151,7 +151,7 @@ proc checkLoggedIn(c: TForumData) =
     )
     c.previousVisitAt = personRow[1].parseInt
     let diff = getTime() - fromUnix(personRow[0].parseInt)
-    if diff.minutes > 30:
+    if diff.inMinutes > 30:
       c.previousVisitAt = personRow[0].parseInt
       db.exec(
         sql"""
@@ -238,7 +238,7 @@ proc verifyIdentHash(
   let newIdent = makeIdentHash(name, row[0], epoch, row[1])
   # Check that it hasn't expired.
   let diff = getTime() - epoch.fromUnix()
-  if diff.hours > 2:
+  if diff.inHours > 2:
     raise newForumError("Link expired")
   if newIdent != ident:
     raise newForumError("Invalid ident hash")
@@ -498,7 +498,7 @@ proc updatePost(c: TForumData, postId: int, content: string,
 
   # Verify that the current user has permissions to edit the specified post.
   let creation = fromUnix(postRow[1].parseInt)
-  let isArchived = (getTime() - creation).weeks > 8
+  let isArchived = (getTime() - creation).inWeeks > 8
   let canEdit = c.rank == Admin or c.userid == postRow[0]
   if isArchived:
     raise newForumError("This post is archived and can no longer be edited")

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -434,8 +434,9 @@ proc executeReply(c: TForumData, threadId: int, content: string,
     else:
       raise newForumError("You are not allowed to post")
 
-  if rateLimitCheck(c):
-    raise newForumError("You're posting too fast!")
+  when not defined(skipRateLimitCheck):
+    if rateLimitCheck(c):
+      raise newForumError("You're posting too fast!")
 
   if content.strip().len == 0:
     raise newForumError("Message cannot be empty")
@@ -567,8 +568,9 @@ proc executeNewThread(c: TForumData, subject, msg, categoryID: string): (int64, 
   if not validateRst(c, msg):
     raise newForumError("Message needs to be valid RST", @["msg"])
 
-  if rateLimitCheck(c):
-    raise newForumError("You're posting too fast!")
+  when not defined(skipRateLimitCheck):
+    if rateLimitCheck(c):
+      raise newForumError("You're posting too fast!")
 
   result[0] = tryInsertID(db, query, subject, categoryID).int
   if result[0] < 0:

--- a/src/frontend/addcategorymodal.nim
+++ b/src/frontend/addcategorymodal.nim
@@ -1,0 +1,87 @@
+when defined(js):
+  import sugar, httpcore, options, json, strutils
+  import dom except Event
+  import jsffi except `&`
+
+  include karax/prelude
+  import karax / [kajax, kdom, vdom]
+
+  import error, category
+  import category, karaxutils
+
+  type
+    AddCategoryModal* = ref object of VComponent
+      modalShown: bool
+      loading: bool
+      error: Option[PostError]
+      onAddCategory: CategoryEvent
+
+  let nullCategory: CategoryEvent = proc (category: Category) = discard
+
+  proc newAddCategoryModal*(onAddCategory=nullCategory): AddCategoryModal =
+    result = AddCategoryModal(
+      modalShown: false,
+      loading: false,
+      onAddCategory: onAddCategory
+    )
+
+  proc onAddCategoryPost(httpStatus: int, response: kstring, state: AddCategoryModal) =
+    postFinished:
+      state.modalShown = false
+      let j = parseJson($response)
+      let category = j.to(Category)
+
+      state.onAddCategory(category)
+
+  proc onAddCategoryClick(state: AddCategoryModal) =
+    state.loading = true
+    state.error = none[PostError]()
+
+    let uri = makeUri("createCategory")
+    let form = dom.document.getElementById("add-category-form")
+    let formData = newFormData(form)
+
+    ajaxPost(uri, @[], formData.to(cstring),
+             (s: int, r: kstring) => onAddCategoryPost(s, r, state))
+
+  proc setModalShown*(state: AddCategoryModal, visible: bool) =
+    state.modalShown = visible
+    state.markDirty()
+
+  proc onModalClose(state: AddCategoryModal, ev: Event, n: VNode) =
+    state.setModalShown(false)
+    ev.preventDefault()
+
+  proc render*(state: AddCategoryModal): VNode =
+    result = buildHtml():
+      tdiv(class=class({"active": state.modalShown}, "modal modal-sm")):
+        a(href="", class="modal-overlay", "aria-label"="close",
+          onClick=(ev: Event, n: VNode) => onModalClose(state, ev, n))
+        tdiv(class="modal-container"):
+          tdiv(class="modal-header"):
+            tdiv(class="card-title h5"):
+              text "Add New Category"
+          tdiv(class="modal-body"):
+            form(id="add-category-form"):
+              genFormField(
+                state.error, "name", "Name", "text", false,
+                placeholder="Category Name")
+              genFormField(
+                state.error, "color", "Color", "color", false,
+                placeholder="#XXYYZZ"
+              )
+              genFormField(
+                state.error,
+                "description",
+                "Description",
+                "text",
+                true,
+                placeholder="Description"
+              )
+          tdiv(class="modal-footer"):
+            button(
+              id="add-category-btn",
+              class="btn btn-primary",
+              onClick=(ev: Event, n: VNode) =>
+                    state.onAddCategoryClick()):
+              text "Add"

--- a/src/frontend/category.nim
+++ b/src/frontend/category.nim
@@ -10,6 +10,9 @@ type
   CategoryList* = ref object
     categories*: seq[Category]
 
+  CategoryEvent* = proc (category: Category) {.closure.}
+  CategoryChangeEvent* = proc (oldCategory: Category, newCategory: Category) {.closure.}
+
 const categoryDescriptionCharLimit = 250
 
 proc cmpNames*(cat1: Category, cat2: Category): int =

--- a/src/frontend/category.nim
+++ b/src/frontend/category.nim
@@ -5,6 +5,7 @@ type
     name*: string
     description*: string
     color*: string
+    numTopics*: int
 
   CategoryList* = ref object
     categories*: seq[Category]

--- a/src/frontend/category.nim
+++ b/src/frontend/category.nim
@@ -20,7 +20,7 @@ when defined(js):
   import karax / [vstyles]
   import karaxutils
 
-  proc render*(category: Category, compact=false): VNode =
+  proc render*(category: Category, compact=true): VNode =
     if category.name.len == 0:
       return buildHtml():
         span()

--- a/src/frontend/category.nim
+++ b/src/frontend/category.nim
@@ -10,16 +10,23 @@ type
   CategoryList* = ref object
     categories*: seq[Category]
 
+const categoryDescriptionCharLimit = 250
+
 proc cmpNames*(cat1: Category, cat2: Category): int =
   cat1.name.cmp(cat2.name)
 
 when defined(js):
   include karax/prelude
   import karax / [vstyles]
+  import karaxutils
 
-  proc render*(category: Category): VNode =
-    result = buildHtml():
-      if category.name.len >= 0:
+  proc render*(category: Category, compact=false): VNode =
+    if category.name.len == 0:
+      return buildHtml():
+        span()
+
+    result = buildhtml(tdiv):
+      tdiv(class="category-status"):
         tdiv(class="category",
              title=category.description,
              "data-color"="#" & category.color):
@@ -28,6 +35,11 @@ when defined(js):
                  (StyleAttr.border,
                   kstring"0.3rem solid #" & category.color)
           ))
-          text category.name
-      else:
-        span()
+          span(class="category-name"):
+            text category.name
+          if not compact:
+            span(class="topic-count"):
+              text "× " & $category.numTopics
+      if not compact:
+        tdiv(class="category-description"):
+          text category.description.limit(categoryDescriptionCharLimit)

--- a/src/frontend/categorylist.nim
+++ b/src/frontend/categorylist.nim
@@ -1,0 +1,83 @@
+import strformat, times, options, json, httpcore, sugar, strutils, uri
+
+import category
+
+when defined(js):
+  include karax/prelude
+  import karax / [vstyles, kajax, kdom]
+
+  import karaxutils, error, user, mainbuttons
+
+  type
+    State = ref object
+      list: Option[CategoryList]
+      loading: bool
+      status: HttpCode
+
+  proc newState(): State =
+    State(
+      list: none[CategoryList](),
+      loading: false,
+      status: Http200
+    )
+  var
+    state = newState()
+
+  proc genCategory(category: Category, noBorder = false): VNode =
+    result = buildHtml():
+      tr(class=class({"no-border": noBorder})):
+        td(style=style((StyleAttr.borderLeftColor, kstring("#" & category.color))), class="category"):
+          h4(class="category-title"):
+            a(href=makeUri("/c/" & $category.id)):
+              tdiv():
+                tdiv(class="category-name"):
+                  text category.name
+          tdiv(class="category-description"):
+            text category.description
+        td(class="topics"):
+          text "Topics"
+
+  proc onCategoriesRetrieved(httpStatus: int, response: kstring) =
+    state.loading = false
+    state.status = httpStatus.HttpCode
+    if state.status != Http200: return
+
+    let parsed = parseJson($response)
+    let list = to(parsed, CategoryList)
+
+    if state.list.isSome:
+      state.list.get().categories.add(list.categories)
+    else:
+      state.list = some(list)
+
+  proc renderCategories(): VNode =
+    if state.status != Http200:
+      return renderError("Couldn't retrieve threads.", state.status)
+
+    if state.list.isNone:
+      if not state.loading:
+        state.loading = true
+        ajaxGet(makeUri("categories.json"), @[], onCategoriesRetrieved)
+
+      return buildHtml(tdiv(class="loading loading-lg"))
+
+    let list = state.list.get()
+
+    return buildHtml():
+      section(class="category-list"):
+        table(id="categories-list", class="table"):
+          thead():
+            tr:
+              th(text "Category")
+              th(text "Topics")
+          tbody():
+            for i in 0 ..< list.categories.len:
+              let category = list.categories[i]
+
+              let isLastCategory = i+1 == list.categories.len
+              genCategory(category, noBorder=isLastCategory)
+
+  proc renderCategoryList*(currentUser: Option[User]): VNode =
+    result = buildHtml(tdiv):
+      renderMainButtons(currentUser)
+      renderCategories()

--- a/src/frontend/categorylist.nim
+++ b/src/frontend/categorylist.nim
@@ -1,10 +1,10 @@
-import strformat, times, options, json, httpcore, sugar, strutils, uri
+import options, json, httpcore
 
 import category
 
 when defined(js):
   include karax/prelude
-  import karax / [vstyles, kajax, kdom]
+  import karax / [vstyles, kajax]
 
   import karaxutils, error, user, mainbuttons
 

--- a/src/frontend/categorylist.nim
+++ b/src/frontend/categorylist.nim
@@ -27,8 +27,8 @@ when defined(js):
     result = buildHtml():
       tr(class=class({"no-border": noBorder})):
         td(style=style((StyleAttr.borderLeftColor, kstring("#" & category.color))), class="category"):
-          h4(class="category-title"):
-            a(href=makeUri("/c/" & $category.id), id="category-" & category.name.slug):
+          h4(class="category-title", id="category-" & category.name.slug):
+            a(href=makeUri("/c/" & $category.id)):
               tdiv():
                 tdiv(class="category-name"):
                   text category.name

--- a/src/frontend/categorylist.nim
+++ b/src/frontend/categorylist.nim
@@ -28,14 +28,14 @@ when defined(js):
       tr(class=class({"no-border": noBorder})):
         td(style=style((StyleAttr.borderLeftColor, kstring("#" & category.color))), class="category"):
           h4(class="category-title"):
-            a(href=makeUri("/c/" & $category.id)):
+            a(href=makeUri("/c/" & $category.id), id="category-" & category.name.slug):
               tdiv():
                 tdiv(class="category-name"):
                   text category.name
           tdiv(class="category-description"):
             text category.description
         td(class="topics"):
-          text "Topics"
+          text $category.numTopics
 
   proc onCategoriesRetrieved(httpStatus: int, response: kstring) =
     state.loading = false

--- a/src/frontend/categorypicker.nim
+++ b/src/frontend/categorypicker.nim
@@ -1,25 +1,24 @@
 when defined(js):
   import sugar, httpcore, options, json, strutils, algorithm
   import dom except Event
-  import jsffi except `&`
 
   include karax/prelude
   import karax / [kajax, kdom, vdom]
 
   import error, category, user
-  import category, karaxutils
+  import category, karaxutils, addcategorymodal
 
   type
     CategoryPicker* = ref object of VComponent
       list: Option[CategoryList]
       selectedCategoryID*: int
       loading: bool
-      modalShown: bool
       addEnabled: bool
       status: HttpCode
       error: Option[PostError]
-      onCategoryChange: proc (oldCategory: Category, newCategory: Category)
-      onAddCategory: proc (category: Category)
+      addCategoryModal: AddCategoryModal
+      onCategoryChange: CategoryChangeEvent
+      onAddCategory: CategoryEvent
 
   proc onCategoryLoad(state: CategoryPicker): proc (httpStatus: int, response: kstring) =
     return
@@ -51,18 +50,26 @@ when defined(js):
         return cat
     raise newException(IndexError, "Category at " & $id & " not found!")
 
-  proc nullAddCategory(category: Category) = discard
-  proc nullCategoryChange(oldCategory: Category, newCategory: Category) = discard
+  let nullAddCategory: CategoryEvent = proc (category: Category) = discard
+  let nullCategoryChange: CategoryChangeEvent = proc (oldCategory: Category, newCategory: Category) = discard
 
-  proc newCategoryPicker*(
-      onCategoryChange: proc(oldCategory: Category, newCategory: Category) = nullCategoryChange,
-      onAddCategory: proc(category: Category) = nullAddCategory
-    ): CategoryPicker =
+  proc select*(state: CategoryPicker, id: int) =
+    state.selectedCategoryID = id
+    state.markDirty()
+
+  proc onCategory(state: CategoryPicker): CategoryEvent =
+    result =
+      proc (category: Category) =
+        state.list.get().categories.add(category)
+        state.list.get().categories.sort(cmpNames)
+        state.select(category.id)
+        state.onAddCategory(category)
+
+  proc newCategoryPicker*(onCategoryChange=nullCategoryChange, onAddCategory=nullAddCategory): CategoryPicker =
     result = CategoryPicker(
       list: none[CategoryList](),
       selectedCategoryID: 0,
       loading: false,
-      modalShown: false,
       addEnabled: false,
       status: Http200,
       error: none[PostError](),
@@ -70,12 +77,13 @@ when defined(js):
       onAddCategory: onAddCategory
     )
 
+    let state = result
+    result.addCategoryModal = newAddCategoryModal(
+      onAddCategory=onCategory(state)
+    )
+
   proc setAddEnabled*(state: CategoryPicker, enabled: bool) =
     state.addEnabled = enabled
-
-  proc select*(state: CategoryPicker, id: int) =
-    state.selectedCategoryID = id
-    state.markDirty()
 
   proc onCategoryClick(state: CategoryPicker, category: Category): proc (ev: Event, n: VNode) =
     # this is necessary to capture the right value
@@ -86,81 +94,18 @@ when defined(js):
         state.select(cat.id)
         state.onCategoryChange(oldCategory, cat)
 
-  proc onAddCategoryPost(httpStatus: int, response: kstring, state: CategoryPicker) =
-    postFinished:
-      state.modalShown = false
-      let j = parseJson($response)
-      let category = j.to(Category)
-
-      state.list.get().categories.add(category)
-      state.list.get().categories.sort(cmpNames)
-      state.select(category.id)
-
-      state.onAddCategory(category)
-
-  proc onAddCategoryClick(state: CategoryPicker) =
-    state.loading = true
-    state.error = none[PostError]()
-
-    let uri = makeUri("createCategory")
-    let form = dom.document.getElementById("add-category-form")
-    let formData = newFormData(form)
-
-    ajaxPost(uri, @[], formData.to(cstring),
-             (s: int, r: kstring) => onAddCategoryPost(s, r, state))
-
-  proc onClose(ev: Event, n: VNode, state: CategoryPicker) =
-    state.modalShown = false
-    state.markDirty()
-    ev.preventDefault()
-
   proc genAddCategory(state: CategoryPicker): VNode =
     result = buildHtml():
       tdiv(id="add-category"):
         button(class="plus-btn btn btn-link",
                onClick=(ev: Event, n: VNode) => (
-                 state.modalShown = true;
-                 state.markDirty()
+                 state.addCategoryModal.setModalShown(true)
                )):
           italic(class="fas fa-plus")
-        tdiv(class=class({"active": state.modalShown}, "modal modal-sm")):
-          a(href="", class="modal-overlay", "aria-label"="close",
-            onClick=(ev: Event, n: VNode) => onClose(ev, n, state))
-          tdiv(class="modal-container"):
-            tdiv(class="modal-header"):
-              tdiv(class="card-title h5"):
-                text "Add New Category"
-            tdiv(class="modal-body"):
-              form(id="add-category-form"):
-                genFormField(
-                  state.error, "name", "Name", "text", false,
-                  placeholder="Category Name")
-                genFormField(
-                  state.error, "color", "Color", "color", false,
-                  placeholder="#XXYYZZ"
-                )
-                genFormField(
-                  state.error,
-                  "description",
-                  "Description",
-                  "text",
-                  true,
-                  placeholder="Description"
-                )
-            tdiv(class="modal-footer"):
-              button(
-                id="add-category-btn",
-                class="btn btn-primary",
-                onClick=(ev: Event, n: VNode) =>
-                      state.onAddCategoryClick()):
-                text "Add"
+        render(state.addCategoryModal)
 
   proc render*(state: CategoryPicker, currentUser: Option[User], compact=true): VNode =
-    let loggedIn = currentUser.isSome()
-    let currentAdmin =
-      loggedIn and currentUser.get().rank == Admin
-
-    if currentAdmin:
+    if currentUser.isAdmin():
       state.setAddEnabled(true)
 
     if state.status != Http200:

--- a/src/frontend/categorypicker.nim
+++ b/src/frontend/categorypicker.nim
@@ -155,7 +155,7 @@ when defined(js):
                       state.onAddCategoryClick()):
                 text "Add"
 
-  proc render*(state: CategoryPicker, currentUser: Option[User]): VNode =
+  proc render*(state: CategoryPicker, currentUser: Option[User], compact=false): VNode =
     let loggedIn = currentUser.isSome()
     let currentAdmin =
       loggedIn and currentUser.get().rank == Admin
@@ -178,7 +178,7 @@ when defined(js):
         tdiv(class="dropdown"):
           a(class="btn btn-link dropdown-toggle", tabindex="0"):
             tdiv(class="selected-category d-inline-block"):
-              render(selectedCategory)
+              render(selectedCategory, compact=true)
             text " "
             italic(class="fas fa-caret-down")
           ul(class="menu"):
@@ -186,6 +186,6 @@ when defined(js):
               li(class="menu-item"):
                 a(class="category-" & $category.id & " " & category.name.slug,
                   onClick=onCategoryClick(state, category)):
-                  render(category)
+                  render(category, compact)
         if state.addEnabled:
           genAddCategory(state)

--- a/src/frontend/categorypicker.nim
+++ b/src/frontend/categorypicker.nim
@@ -21,9 +21,6 @@ when defined(js):
       onCategoryChange: proc (oldCategory: Category, newCategory: Category)
       onAddCategory: proc (category: Category)
 
-  proc slug(name: string): string =
-    name.strip().replace(" ", "-").toLowerAscii
-
   proc onCategoryLoad(state: CategoryPicker): proc (httpStatus: int, response: kstring) =
     return
       proc (httpStatus: int, response: kstring) =

--- a/src/frontend/categorypicker.nim
+++ b/src/frontend/categorypicker.nim
@@ -155,7 +155,7 @@ when defined(js):
                       state.onAddCategoryClick()):
                 text "Add"
 
-  proc render*(state: CategoryPicker, currentUser: Option[User], compact=false): VNode =
+  proc render*(state: CategoryPicker, currentUser: Option[User], compact=true): VNode =
     let loggedIn = currentUser.isSome()
     let currentAdmin =
       loggedIn and currentUser.get().rank == Admin
@@ -178,7 +178,7 @@ when defined(js):
         tdiv(class="dropdown"):
           a(class="btn btn-link dropdown-toggle", tabindex="0"):
             tdiv(class="selected-category d-inline-block"):
-              render(selectedCategory, compact=true)
+              render(selectedCategory)
             text " "
             italic(class="fas fa-caret-down")
           ul(class="menu"):

--- a/src/frontend/error.nim
+++ b/src/frontend/error.nim
@@ -1,11 +1,11 @@
-import options, httpcore
+import httpcore
 type
   PostError* = object
     errorFields*: seq[string] ## IDs of the fields with an error.
     message*: string
 
 when defined(js):
-  import json
+  import json, options
   include karax/prelude
 
   import karaxutils

--- a/src/frontend/forum.nim
+++ b/src/frontend/forum.nim
@@ -2,6 +2,7 @@ import options, tables, sugar, httpcore
 from dom import window, Location, document, decodeURI
 
 include karax/prelude
+import karax/[kdom]
 import jester/[patterns]
 
 import threadlist, postlist, header, profile, newthread, error, about
@@ -55,6 +56,10 @@ proc onPopState(event: dom.Event) =
   if state.url.href != window.location.href:
     state = newState() # Reload the state to remove stale data.
   state.url = copyLocation(window.location)
+
+  # For some reason this is needed so that the back/forward buttons reload
+  # the post list when different categories are selected
+  window.location.reload()
 
   redraw()
 

--- a/src/frontend/forum.nim
+++ b/src/frontend/forum.nim
@@ -5,6 +5,7 @@ include karax/prelude
 import jester/[patterns]
 
 import threadlist, postlist, header, profile, newthread, error, about
+import categorylist
 import resetpassword, activateemail, search
 import karaxutils
 
@@ -81,6 +82,14 @@ proc render(): VNode =
   result = buildHtml(tdiv()):
     renderHeader()
     route([
+      r("/categories",
+        (params: Params) =>
+          (renderCategoryList(getLoggedInUser()))
+      ),
+      r("/c/@id",
+        (params: Params) =>
+          (renderThreadList(getLoggedInUser(), params["id"].parseInt))
+      ),
       r("/newthread",
         (params: Params) =>
           (render(state.newThread, getLoggedInUser()))

--- a/src/frontend/header.nim
+++ b/src/frontend/header.nim
@@ -1,4 +1,4 @@
-import options, times, httpcore, json, sugar
+import options, httpcore
 
 import user
 type
@@ -7,6 +7,7 @@ type
     recaptchaSiteKey*: Option[string]
 
 when defined(js):
+  import times, json, sugar
   include karax/prelude
   import karax / [kajax, kdom]
 

--- a/src/frontend/header.nim
+++ b/src/frontend/header.nim
@@ -39,15 +39,15 @@ when defined(js):
       loading: false,
       status: Http200,
       loginModal: newLoginModal(
-        () => (state.lastUpdate = fromUnix(0); getStatus()),
+        () => (state.lastUpdate = fromUnix(0); getStatus(); window.location.reload()),
         () => state.signupModal.show()
       ),
       signupModal: newSignupModal(
-        () => (state.lastUpdate = fromUnix(0); getStatus()),
+        () => (state.lastUpdate = fromUnix(0); getStatus(); window.location.reload()),
         () => state.loginModal.show()
       ),
       userMenu: newUserMenu(
-        () => (state.lastUpdate = fromUnix(0); getStatus(logout=true))
+        () => (state.lastUpdate = fromUnix(0); getStatus(logout=true); window.location.reload())
       )
     )
 

--- a/src/frontend/karaxutils.nim
+++ b/src/frontend/karaxutils.nim
@@ -1,5 +1,16 @@
 import strutils, strformat, parseutils, tables
 
+proc limit*(str: string, n: int): string =
+  ## Limit the number of characters in a string. Ends with a elipsis
+  if str.len > n:
+    return str[0..<n-3] & "..."
+  else:
+    return str
+
+proc slug*(name: string): string =
+  ## Transforms text into a url slug
+  name.strip().replace(" ", "-").toLowerAscii
+
 proc parseIntSafe*(s: string, value: var int) {.noSideEffect.} =
   ## parses `s` into an integer in the range `validRange`. If successful,
   ## `value` is modified to contain the result. Otherwise no exception is

--- a/src/frontend/karaxutils.nim
+++ b/src/frontend/karaxutils.nim
@@ -97,6 +97,7 @@ when defined(js):
       let url = n.getAttr("href")
 
       navigateTo(url)
+      window.location.href = url
 
   proc newFormData*(form: dom.Element): FormData
     {.importcpp: "new FormData(@)", constructor.}

--- a/src/frontend/mainbuttons.nim
+++ b/src/frontend/mainbuttons.nim
@@ -31,7 +31,7 @@ when defined(js):
               li: text "dev" ]#
           if categoryId != -1:
             catPicker.selectedCategoryID = categoryId
-            render(catPicker, currentUser)
+            render(catPicker, currentUser, compact=false)
 
           for btn in buttons:
             let active = btn.url == window.location.href

--- a/src/frontend/mainbuttons.nim
+++ b/src/frontend/mainbuttons.nim
@@ -3,16 +3,22 @@ import user
 
 when defined(js):
   include karax/prelude
-  import karax / [vstyles, kajax, kdom]
+  import karax / [kdom]
 
-  import karaxutils, error, user
+  import karaxutils, user, categorypicker, category
 
   let buttons = [
     (name: "Latest", url: makeUri("/"), id: "latest-btn"),
     (name: "Categories", url: makeUri("/categories"), id: "categories-btn"),
   ]
 
-  proc renderMainButtons*(currentUser: Option[User]): VNode =
+  proc onSelectedCategoryChanged(oldCategory: Category, newCategory: Category) =
+    let uri = makeUri("/c/" & $newCategory.id)
+    navigateTo(uri)
+
+  let catPicker = newCategoryPicker(onCategoryChange=onSelectedCategoryChanged)
+
+  proc renderMainButtons*(currentUser: Option[User], categoryId = -1): VNode =
     result = buildHtml():
       section(class="navbar container grid-xl", id="main-buttons"):
         section(class="navbar-section"):
@@ -23,6 +29,9 @@ when defined(js):
             ul(class="menu"):
               li: text "community"
               li: text "dev" ]#
+          if categoryId != -1:
+            catPicker.selectedCategoryID = categoryId
+            render(catPicker, currentUser)
 
           for btn in buttons:
             let active = btn.url == window.location.href

--- a/src/frontend/mainbuttons.nim
+++ b/src/frontend/mainbuttons.nim
@@ -1,0 +1,37 @@
+import options
+import user
+
+when defined(js):
+  include karax/prelude
+  import karax / [vstyles, kajax, kdom]
+
+  import karaxutils, error, user
+
+  let buttons = [
+    (name: "Latest", url: makeUri("/"), id: "latest-btn"),
+    (name: "Categories", url: makeUri("/categories"), id: "categories-btn"),
+  ]
+
+  proc renderMainButtons*(currentUser: Option[User]): VNode =
+    result = buildHtml():
+      section(class="navbar container grid-xl", id="main-buttons"):
+        section(class="navbar-section"):
+          #[tdiv(class="dropdown"):
+            a(href="#", class="btn dropdown-toggle"):
+              text "Filter "
+              italic(class="fas fa-caret-down")
+            ul(class="menu"):
+              li: text "community"
+              li: text "dev" ]#
+
+          for btn in buttons:
+            let active = btn.url == window.location.href
+            a(id=btn.id, href=btn.url):
+              button(class=class({"btn-primary": active, "btn-link": not active}, "btn")):
+                text btn.name
+        section(class="navbar-section"):
+          if currentUser.isSome():
+            a(id="new-thread-btn", href=makeUri("/newthread"), onClick=anchorCB):
+              button(class="btn btn-secondary"):
+                italic(class="fas fa-plus")
+                text " New Thread"

--- a/src/frontend/mainbuttons.nim
+++ b/src/frontend/mainbuttons.nim
@@ -16,7 +16,16 @@ when defined(js):
     let uri = makeUri("/c/" & $newCategory.id)
     navigateTo(uri)
 
-  let catPicker = newCategoryPicker(onCategoryChange=onSelectedCategoryChanged)
+  type
+    State = ref object
+      categoryPicker: CategoryPicker
+
+  proc newState(): State =
+    State(
+      categoryPicker: newCategoryPicker(onCategoryChange=onSelectedCategoryChanged),
+    )
+
+  let state = newState()
 
   proc renderMainButtons*(currentUser: Option[User], categoryId = -1): VNode =
     result = buildHtml():
@@ -30,8 +39,8 @@ when defined(js):
               li: text "community"
               li: text "dev" ]#
           if categoryId != -1:
-            catPicker.selectedCategoryID = categoryId
-            render(catPicker, currentUser, compact=false)
+            state.categoryPicker.selectedCategoryID = categoryId
+            render(state.categoryPicker, currentUser, compact=false)
 
           for btn in buttons:
             let active = btn.url == window.location.href

--- a/src/frontend/newthread.nim
+++ b/src/frontend/newthread.nim
@@ -65,7 +65,7 @@ when defined(js):
             tdiv():
               label(class="d-inline-block form-label"):
                 text "Category"
-              render(state.categoryPicker, currentUser)
+              render(state.categoryPicker, currentUser, compact=false)
             renderContent(state.replyBox, none[Thread](), none[Post]())
           tdiv(class="footer"):
 

--- a/src/frontend/post.nim
+++ b/src/frontend/post.nim
@@ -1,6 +1,6 @@
 import options
 
-import user, threadlist
+import user
 
 type
   PostInfo* = object
@@ -58,7 +58,7 @@ type
     email*: Option[string]
 
 when defined(js):
-  import karaxutils
+  import karaxutils, threadlist
 
   proc renderPostUrl*(post: Post, thread: Thread): string =
     renderPostUrl(thread.id, post.id)

--- a/src/frontend/postlist.nim
+++ b/src/frontend/postlist.nim
@@ -215,7 +215,7 @@ when defined(js):
     result = buildHtml():
       tdiv():
         if authoredByUser or currentAdmin:
-          render(state.categoryPicker, currentUser)
+          render(state.categoryPicker, currentUser, compact=false)
         else:
           render(thread.category)
 

--- a/src/frontend/threadlist.nim
+++ b/src/frontend/threadlist.nim
@@ -111,7 +111,7 @@ when defined(js):
             text thread.topic
         if displayCategory:
           td():
-            render(thread.category, compact=true)
+            render(thread.category)
         genUserAvatars(thread.users)
         td(): text $thread.replies
         td(class=class({

--- a/src/frontend/threadlist.nim
+++ b/src/frontend/threadlist.nim
@@ -109,9 +109,8 @@ when defined(js):
           a(href=makeUri("/t/" & $thread.id),
             onClick=anchorCB):
             text thread.topic
-        if displayCategory:
-          td():
-            render(thread.category)
+        td(class=class({"d-none": not displayCategory})):
+          render(thread.category)
         genUserAvatars(thread.users)
         td(): text $thread.replies
         td(class=class({
@@ -187,6 +186,8 @@ when defined(js):
 
       return buildHtml(tdiv(class="loading loading-lg"))
 
+    let displayCategory = true
+
     let list = state.list.get()
     result = buildHtml():
       section(class="thread-list"):
@@ -194,8 +195,8 @@ when defined(js):
           thead():
             tr:
               th(text "Topic")
-              if categoryId == -1:
-                th(text "Category")
+              th(class=class({"d-none": not displayCategory})):
+                text "Category"
               th(style=style((StyleAttr.width, kstring"8rem"))): text "Users"
               th(text "Replies")
               th(text "Views")
@@ -209,7 +210,7 @@ when defined(js):
               let (isLastUnseen, isNew) = getInfo(list.threads, i, currentUser)
               genThread(thread, isNew,
                         noBorder=isLastUnseen or isLastThread,
-                        displayCategory=categoryId == -1)
+                        displayCategory=displayCategory)
               if isLastUnseen and (not isLastThread):
                 tr(class="last-visit-separator"):
                   td(colspan="6"):

--- a/src/frontend/threadlist.nim
+++ b/src/frontend/threadlist.nim
@@ -88,7 +88,7 @@ when defined(js):
     else:
       return $duration.inSeconds & "s"
 
-  proc genThread(thread: Thread, isNew: bool, noBorder: bool): VNode =
+  proc genThread(thread: Thread, isNew: bool, noBorder: bool, displayCategory=true): VNode =
     let isOld = (getTime() - thread.creation.fromUnix).inWeeks > 2
     let isBanned = thread.author.rank.isBanned()
     result = buildHtml():
@@ -109,8 +109,9 @@ when defined(js):
           a(href=makeUri("/t/" & $thread.id),
             onClick=anchorCB):
             text thread.topic
-        td():
-          render(thread.category)
+        if displayCategory:
+          td():
+            render(thread.category, compact=true)
         genUserAvatars(thread.users)
         td(): text $thread.replies
         td(class=class({
@@ -193,7 +194,8 @@ when defined(js):
           thead():
             tr:
               th(text "Topic")
-              th(text "Category")
+              if categoryId == -1:
+                th(text "Category")
               th(style=style((StyleAttr.width, kstring"8rem"))): text "Users"
               th(text "Replies")
               th(text "Views")
@@ -206,7 +208,8 @@ when defined(js):
               let isLastThread = i+1 == list.threads.len
               let (isLastUnseen, isNew) = getInfo(list.threads, i, currentUser)
               genThread(thread, isNew,
-                        noBorder=isLastUnseen or isLastThread)
+                        noBorder=isLastUnseen or isLastThread,
+                        displayCategory=categoryId == -1)
               if isLastUnseen and (not isLastThread):
                 tr(class="last-visit-separator"):
                   td(colspan="6"):
@@ -224,5 +227,5 @@ when defined(js):
 
   proc renderThreadList*(currentUser: Option[User], categoryId = -1): VNode =
     result = buildHtml(tdiv):
-      renderMainButtons(currentUser)
+      renderMainButtons(currentUser, categoryId=categoryId)
       genThreadList(currentUser, categoryId)

--- a/src/frontend/threadlist.nim
+++ b/src/frontend/threadlist.nim
@@ -1,4 +1,4 @@
-import strformat, times, options, json, httpcore
+import strformat, times, options, json, httpcore, sugar
 
 import category, user
 

--- a/src/frontend/user.nim
+++ b/src/frontend/user.nim
@@ -1,4 +1,4 @@
-import times
+import times, options
 
 type
   # If you add more "Banned" states, be sure to modify forum's threadsQuery too.
@@ -26,6 +26,9 @@ type
 
 proc isOnline*(user: User): bool =
   return getTime().toUnix() - user.lastOnline < (60*5)
+
+proc isAdmin*(user: Option[User]): bool =
+  return user.isSome and user.get().rank == Admin
 
 proc `==`*(u1, u2: User): bool =
   u1.name == u2.name

--- a/tests/browsertester.nim
+++ b/tests/browsertester.nim
@@ -23,7 +23,7 @@ const baseUrl = "http://localhost:" & $port & "/"
 template withBackend(body: untyped): untyped =
   ## Starts a new backend instance.
 
-  spawn runProcess("nimble -y runbackend")
+  spawn runProcess("nimble -y testbackend")
   defer:
     discard execCmd("killall " & backend)
 
@@ -46,6 +46,8 @@ template withBackend(body: untyped): untyped =
 import browsertests/[scenario1, threads, issue181, categories]
 
 proc main() =
+  # Kill any already running instances
+  discard execCmd("killall geckodriver")
   spawn runProcess("geckodriver -p 4444 --log config")
   defer:
     discard execCmd("killall geckodriver")

--- a/tests/browsertester.nims
+++ b/tests/browsertester.nims
@@ -1,1 +1,2 @@
 --threads:on
+--path:"../src/frontend"

--- a/tests/browsertests/categories.nim
+++ b/tests/browsertests/categories.nim
@@ -1,13 +1,11 @@
-import unittest, options, os, common
+import unittest, options, common
 
 import webdriver
 
 proc selectCategory(session: Session, name: string) =
   with session:
     click "#category-selection .dropdown-toggle"
-
     click "#category-selection ." & name
-
 
 proc categoriesUserTests(session: Session, baseUrl: string) =
   let
@@ -33,15 +31,12 @@ proc categoriesUserTests(session: Session, baseUrl: string) =
     test "can create category thread":
       with session:
         click "#new-thread-btn"
-
         sendKeys "#thread-title", title
 
         selectCategory "fun"
-
         sendKeys "#reply-textarea", content
 
         click "#create-thread-btn"
-
         checkText "#thread-title .category", "Fun"
 
         navigate baseUrl
@@ -72,7 +67,6 @@ proc categoriesAdminTests(session: Session, baseUrl: string) =
         clear "#add-category input[name='name']"
         clear "#add-category input[name='color']"
         clear "#add-category input[name='description']"
-
 
         sendKeys "#add-category input[name='name']", name
         sendKeys "#add-category input[name='color']", color

--- a/tests/browsertests/categories.nim
+++ b/tests/browsertests/categories.nim
@@ -1,4 +1,4 @@
-import unittest, options, common, os
+import unittest, common
 import webdriver
 
 import karaxutils

--- a/tests/browsertests/categories.nim
+++ b/tests/browsertests/categories.nim
@@ -49,6 +49,11 @@ proc categoriesUserTests(session: Session, baseUrl: string) =
 
         checkIsNone "#add-category"
 
+    test "no category add available category page":
+      with session:
+        click "#categories-btn"
+        checkIsNone "#add-category"
+
     test "can create category thread":
       with session:
         click "#new-thread-btn"

--- a/tests/browsertests/common.nim
+++ b/tests/browsertests/common.nim
@@ -19,7 +19,7 @@ macro with*(obj: typed, code: untyped): untyped =
 
   # Simply inject obj into call
   for i in 0 ..< result.len:
-    if result[i].kind in {nnkCommand, nnkCall} and $result[i][0].toStrLit != "assert":
+    if result[i].kind in {nnkCommand, nnkCall}:
       result[i].insert(1, obj)
 
   result = getAst(checkCompiles(result, code))

--- a/tests/browsertests/common.nim
+++ b/tests/browsertests/common.nim
@@ -32,19 +32,19 @@ proc elementIsNone(element: Option[Element]): bool =
 
 proc waitForElement*(session: Session, selector: string, strategy=CssSelector, timeout=20000, pollTime=50, waitCondition=elementIsSome): Option[Element]
 
-template click*(session: Session, element: string, strategy=CssSelector) =
+proc click*(session: Session, element: string, strategy=CssSelector) =
   let el = session.waitForElement(element, strategy)
   el.get().click()
 
-template sendKeys*(session: Session, element, keys: string) =
+proc sendKeys*(session: Session, element, keys: string) =
   let el = session.waitForElement(element)
   el.get().sendKeys(keys)
 
-template clear*(session: Session, element: string) =
+proc clear*(session: Session, element: string) =
   let el = session.waitForElement(element)
   el.get().clear()
 
-template sendKeys*(session: Session, element: string, keys: varargs[Key]) =
+proc sendKeys*(session: Session, element: string, keys: varargs[Key]) =
   let el = session.waitForElement(element)
 
   # focus
@@ -52,7 +52,7 @@ template sendKeys*(session: Session, element: string, keys: varargs[Key]) =
   for key in keys:
     session.press(key)
 
-template ensureExists*(session: Session, element: string, strategy=CssSelector) =
+proc ensureExists*(session: Session, element: string, strategy=CssSelector) =
   discard session.waitForElement(element, strategy)
 
 template check*(session: Session, element: string, function: untyped) =
@@ -68,10 +68,10 @@ proc setColor*(session: Session, element, color: string, strategy=CssSelector) =
   let el = session.waitForElement(element, strategy)
   discard session.execute("arguments[0].setAttribute('value', '" & color & "')", el.get())
 
-template checkIsNone*(session: Session, element: string, strategy=CssSelector) =
+proc checkIsNone*(session: Session, element: string, strategy=CssSelector) =
   discard session.waitForElement(element, strategy, waitCondition=elementIsNone)
 
-template checkText*(session: Session, element, expectedValue: string) =
+proc checkText*(session: Session, element, expectedValue: string) =
   let el = session.waitForElement(element)
   check el.get().getText() == expectedValue
 

--- a/tests/browsertests/common.nim
+++ b/tests/browsertests/common.nim
@@ -64,6 +64,10 @@ template check*(session: Session, element: string,
   let el = session.waitForElement(element, strategy)
   check function(el)
 
+proc setColor*(session: Session, element, color: string, strategy=CssSelector) =
+  let el = session.waitForElement(element, strategy)
+  discard session.execute("arguments[0].setAttribute('value', '" & color & "')", el.get())
+
 template checkIsNone*(session: Session, element: string, strategy=CssSelector) =
   discard session.waitForElement(element, strategy, waitCondition=elementIsNone)
 
@@ -105,7 +109,6 @@ proc waitForElements*(
 
   while true:
     let loading = session.findElements(selector, strategy)
-    echo loading
     if loading.len > 0:
       return loading
     sleep(pollTime)

--- a/tests/browsertests/issue181.nim
+++ b/tests/browsertests/issue181.nim
@@ -1,4 +1,4 @@
-import unittest, options, common
+import unittest, common
 
 import webdriver
 

--- a/tests/browsertests/issue181.nim
+++ b/tests/browsertests/issue181.nim
@@ -1,4 +1,4 @@
-import unittest, options, os, common
+import unittest, options, common
 
 import webdriver
 

--- a/tests/browsertests/scenario1.nim
+++ b/tests/browsertests/scenario1.nim
@@ -1,4 +1,4 @@
-import unittest, options, common
+import unittest, common
 
 import webdriver
 

--- a/tests/browsertests/scenario1.nim
+++ b/tests/browsertests/scenario1.nim
@@ -1,4 +1,4 @@
-import unittest, options, os, common
+import unittest, options, common
 
 import webdriver
 

--- a/tests/browsertests/threads.nim
+++ b/tests/browsertests/threads.nim
@@ -1,4 +1,4 @@
-import unittest, options, common
+import unittest, common
 
 import webdriver
 


### PR DESCRIPTION
This is a follow up to https://github.com/nim-lang/nimforum/pull/194. Sorry @dom96 for another long PR ;)

In general, this PR makes categories useful in that users can filter by them and only see the categories that they care about.

**Features**

- New categories list page, which allow selection of a category, similar to Discourse
- Better display of categories in the category picker dropdown. The dropdown now contains the category description and how many topics are in each category
- Ability to change category when already viewing a category

**Code Changes**

- The "Add category" modal was refactored into it's own file so that it could be added to both the categories list page and the categories dropdown
- A reload was added on Login/Logout because state was not being refreshed in some widgets, most notably the Category picker. There is probably a better way to do this, but not without a good refactor. I'll make a note of this and address it in the future
- Made testing a bit easier by waiting for multiple elements
- Added tests for new categories list page