### PR TITLE
Add ability to enable TLS for SMTP

### DIFF
--- a/src/email.nim
+++ b/src/email.nim
@@ -45,9 +45,9 @@ proc sendMail(
     return
 
   var client = newAsyncSmtp()
+  await client.connect(mailer.config.smtpAddress, Port(mailer.config.smtpPort))
   if mailer.config.smtpTls:
     await client.startTls()
-  await client.connect(mailer.config.smtpAddress, Port(mailer.config.smtpPort))
   if mailer.config.smtpUser.len > 0:
     await client.auth(mailer.config.smtpUser, mailer.config.smtpPassword)
 

--- a/src/email.nim
+++ b/src/email.nim
@@ -45,6 +45,8 @@ proc sendMail(
     return
 
   var client = newAsyncSmtp()
+  if mailer.config.smtpTls:
+    await client.startTls()
   await client.connect(mailer.config.smtpAddress, Port(mailer.config.smtpPort))
   if mailer.config.smtpUser.len > 0:
     await client.auth(mailer.config.smtpUser, mailer.config.smtpPassword)

--- a/src/setup_nimforum.nim
+++ b/src/setup_nimforum.nim
@@ -234,7 +234,7 @@ proc initialiseDb(admin: tuple[username, password, email: string],
 proc initialiseConfig(
   name, title, hostname: string,
   recaptcha: tuple[siteKey, secretKey: string],
-  smtp: tuple[address, user, password, fromAddr: string],
+  smtp: tuple[address, user, password, fromAddr: string, tls: bool],
   isDev: bool,
   dbPath: string,
   ga: string=""
@@ -251,6 +251,7 @@ proc initialiseConfig(
     "smtpUser": %smtp.user,
     "smtpPassword": %smtp.password,
     "smtpFromAddr": %smtp.fromAddr,
+    "smtpTls": %smtp.tls,
     "isDev": %isDev,
     "dbPath": %dbPath
   }
@@ -294,6 +295,7 @@ These can be changed later in the generated forum.json file.
   let smtpUser = question("SMTP user: ")
   let smtpPassword = readPasswordFromStdin("SMTP pass: ")
   let smtpFromAddr = question("SMTP sending email address (eg: mail@mail.hostname.com): ")
+  let smtpTls = parseBool(question("Enable TLS for SMTP: "))
 
   echo("The following is optional. You can specify your Google Analytics ID " &
        "if you wish. Otherwise just leave it blank.")
@@ -303,7 +305,7 @@ These can be changed later in the generated forum.json file.
   let dbPath = "nimforum.db"
   initialiseConfig(
     name, title, hostname, (recaptchaSiteKey, recaptchaSecretKey),
-    (smtpAddress, smtpUser, smtpPassword, smtpFromAddr), isDev=false,
+    (smtpAddress, smtpUser, smtpPassword, smtpFromAddr, smtpTls), isDev=false,
     dbPath, ga
   )
 
@@ -338,7 +340,7 @@ when isMainModule:
         "Development Forum",
         "localhost",
         recaptcha=("", ""),
-        smtp=("", "", "", ""),
+        smtp=("", "", "", "", false),
         isDev=true,
         dbPath
       )
@@ -355,7 +357,7 @@ when isMainModule:
         "Test Forum",
         "localhost",
         recaptcha=("", ""),
-        smtp=("", "", "", ""),
+        smtp=("", "", "", "", false),
         isDev=true,
         dbPath
       )

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -17,6 +17,7 @@ type
     smtpUser*: string
     smtpPassword*: string
     smtpFromAddr*: string
+    smtpTls*: bool
     mlistAddress*: string
     recaptchaSecretKey*: string
     recaptchaSiteKey*: string

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -56,6 +56,7 @@ proc loadConfig*(filename = getCurrentDir() / "forum.json"): Config =
   result.smtpUser = root{"smtpUser"}.getStr("")
   result.smtpPassword = root{"smtpPassword"}.getStr("")
   result.smtpFromAddr = root{"smtpFromAddr"}.getStr("")
+  result.smtpTls = root{"smtpTls"}.getBool(false)
   result.mlistAddress = root{"mlistAddress"}.getStr("")
   result.recaptchaSecretKey = root{"recaptchaSecretKey"}.getStr("")
   result.recaptchaSiteKey = root{"recaptchaSiteKey"}.getStr("")


### PR DESCRIPTION
This PR adds a new config option ``smtpTls`` to enable TLS when connection to SMTP. Allows to use SMTP services like Gmail.

Please tell me if I did something wrong :)