### PR TITLE
Add Date header to emails

### DIFF
--- a/src/email.nim
+++ b/src/email.nim
@@ -56,6 +56,9 @@ proc sendMail(
   var headers = otherHeaders
   headers.add(("From", mailer.config.smtpFromAddr))
 
+  let dateHeader = now().utc().format("ddd, dd MMM yyyy hh:mm:ss") & " +0000"
+  headers.add(("Date", dateHeader))
+
   let encoded = createMessage(subject, message,
       toList, @[], headers)
 


### PR DESCRIPTION
UTC time is used because we cannot format time as "Fri, 22 May 2020
06:33:00 +0000" with the times package.

"zz" returns +00 & "zzz" returns +00:00, note that the former doesn't
return minutes value so it'll return +05 for systems in timezone
+0530 & "zzz" will return +05:30 for the same.

Instead of parsing it again & removing ':' manually we use UTC time &
add "+0000".