### PR TITLE
Send confirmation email to updated address

### DIFF
--- a/src/forum.nim
+++ b/src/forum.nim
@@ -774,7 +774,7 @@ proc updateProfile(
       raise newForumError("Rank needs a change when setting new email.")
 
     await sendSecureEmail(
-      mailer, ActivateEmail, c.req, row[0], row[1], row[2], row[3]
+      mailer, ActivateEmail, c.req, row[0], row[1], email, row[3]
     )
 
   validateEmail(email, checkDuplicated=wasEmailChanged)


### PR DESCRIPTION
This will fix https://github.com/nim-lang/nimforum/issues/155.

Currently nimforum sends the confirmation email to the address in
database but it should've sent it to the new address.

Activity: User changes email
Issue: Confirmation email is sent to old address
Fix: Send the confirmation email to updated address