### PR TITLE
properly do #255 - moderators can change categories

### DIFF
--- a/src/frontend/postlist.nim
+++ b/src/frontend/postlist.nim
@@ -209,12 +209,12 @@ when defined(js):
     let loggedIn = currentUser.isSome()
     let authoredByUser =
       loggedIn and currentUser.get().name == thread.author.name
-    let currentAdmin =
-      currentUser.isSome() and currentUser.get().rank == Admin
+    let canChangeCategory =
+      loggedIn and currentUser.get().rank in {Admin, Moderator}
 
     result = buildHtml():
       tdiv():
-        if authoredByUser or currentAdmin:
+        if authoredByUser or canChangeCategory:
           render(state.categoryPicker, currentUser, compact=false)
         else:
           render(thread.category)


### PR DESCRIPTION
The PR #255 was incomplete: moderators still couldn't change categories of the existing threads. This enables them to do it, which is IMO part of moderating job.