### PR TITLE
allowed editing time is now much shorter

### DIFF
--- a/src/forum.nim
+++ b/src/forum.nim
@@ -498,10 +498,10 @@ proc updatePost(c: TForumData, postId: int, content: string,
 
   # Verify that the current user has permissions to edit the specified post.
   let creation = fromUnix(postRow[1].parseInt)
-  let isArchived = (getTime() - creation).inWeeks > 8
+  let isArchived = (getTime() - creation).inHours >= 2
   let canEdit = c.rank == Admin or c.userid == postRow[0]
-  if isArchived:
-    raise newForumError("This post is archived and can no longer be edited")
+  if isArchived and c.rank < Admin:
+    raise newForumError("This post is too old and can no longer be edited")
   if not canEdit:
     raise newForumError("You cannot edit this post")
 


### PR DESCRIPTION
Other forums usually have allowed editing times measured in
*minutes*, we had it in weeks.

Two hours should be plenty of time to edit a post, but more importantly
it should prevent spamming mis-usages that sometimes happened before:
You read a perfectly normal post (usually copy-pasted from somewhere)
and then much later on (when most of us regular forum users don't notice
anymore because we frequently read new threads/posts) it is edited to
contain spammy links and content.

Admins must be able to always edit a post, no matter of its age.