### PR TITLE
Replace webdriver with halonium

### DIFF
--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -21,7 +21,7 @@ requires "sass#649e0701fa5c"
 
 requires "karax#5f21dcd"
 
-requires "webdriver#429933a"
+requires "halonium#f54c83f"
 
 # Tasks
 

--- a/tests/browsertester.nim
+++ b/tests/browsertester.nim
@@ -1,6 +1,6 @@
 import options, osproc, streams, threadpool, os, strformat, httpclient
 
-import webdriver
+import halonium
 
 proc runProcess(cmd: string) =
   let p = startProcess(
@@ -46,22 +46,13 @@ template withBackend(body: untyped): untyped =
 import browsertests/[scenario1, threads, issue181, categories]
 
 proc main() =
-  # Kill any already running instances
-  discard execCmd("killall geckodriver")
-  spawn runProcess("geckodriver -p 4444 --log config")
-  defer:
-    discard execCmd("killall geckodriver")
-
   # Create a fresh DB for the tester.
   doAssert(execCmd("nimble testdb") == QuitSuccess)
 
   doAssert(execCmd("nimble -y frontend") == QuitSuccess)
-  echo("Waiting for geckodriver to startup...")
-  sleep(5000)
 
   try:
-    let driver = newWebDriver()
-    let session = driver.createSession()
+    let session = createSession(Firefox)
 
     withBackend:
       scenario1.test(session, baseUrl)

--- a/tests/browsertests/categories.nim
+++ b/tests/browsertests/categories.nim
@@ -1,5 +1,5 @@
 import unittest, common
-import webdriver
+import halonium
 
 import karaxutils
 
@@ -47,12 +47,12 @@ proc categoriesUserTests(session: Session, baseUrl: string) =
       with session:
         click "#new-thread-btn"
 
-        checkIsNone "#add-category"
+        checkIsNone "#add-category .plus-btn"
 
     test "no category add available category page":
       with session:
         click "#categories-btn"
-        checkIsNone "#add-category"
+        checkIsNone "#add-category .plus-btn"
 
     test "can create category thread":
       with session:
@@ -139,17 +139,17 @@ proc categoriesUserTests(session: Session, baseUrl: string) =
         checkText "#threads-list .thread-title a", "Post 3"
         for element in session.waitForElements("#threads-list .category-name"):
           # Have to user "innerText" because elements are hidden on this page
-          assert element.getProperty("innerText") == "Unsorted"
+          assert element.text == "Unsorted"
 
         selectCategory "announcements"
         checkText "#threads-list .thread-title a", "Post 2"
         for element in session.waitForElements("#threads-list .category-name"):
-          assert element.getProperty("innerText") == "Announcements"
+          assert element.text == "Announcements"
 
         selectCategory "fun"
         checkText "#threads-list .thread-title a", "Post 1"
         for element in session.waitForElements("#threads-list .category-name"):
-          assert element.getProperty("innerText") == "Fun"
+          assert element.text == "Fun"
 
     session.logout()
 
@@ -168,7 +168,7 @@ proc categoriesAdminTests(session: Session, baseUrl: string) =
       with session:
         click "#new-thread-btn"
 
-        ensureExists "#add-category"
+        ensureExists "#add-category .plus-btn"
 
         click "#add-category .plus-btn"
 
@@ -195,10 +195,10 @@ proc categoriesAdminTests(session: Session, baseUrl: string) =
     test "category adding disabled on admin logout":
       with session:
         navigate(baseUrl & "c/0")
-        ensureExists "#add-category"
+        ensureExists "#add-category .plus-btn"
         logout()
 
-        checkIsNone "#add-category"
+        checkIsNone "#add-category .plus-btn"
         navigate baseUrl
 
         login "admin", "admin"

--- a/tests/browsertests/common.nim
+++ b/tests/browsertests/common.nim
@@ -1,9 +1,9 @@
 import os, options, unittest, strutils
-import webdriver
+import halonium
 import macros
 
-const actionDelayMs {.intdefine.} = 0
-## Inserts a delay in milliseconds between automated actions. Useful for debugging tests
+export waitForElement
+export waitForElements
 
 macro with*(obj: typed, code: untyped): untyped =
   ## Execute a set of statements with an object
@@ -24,14 +24,6 @@ macro with*(obj: typed, code: untyped): untyped =
 
   result = getAst(checkCompiles(result, code))
 
-proc elementIsSome(element: Option[Element]): bool =
-  return element.isSome
-
-proc elementIsNone(element: Option[Element]): bool =
-  return element.isNone
-
-proc waitForElement*(session: Session, selector: string, strategy=CssSelector, timeout=20000, pollTime=50, waitCondition=elementIsSome): Option[Element]
-
 proc click*(session: Session, element: string, strategy=CssSelector) =
   let el = session.waitForElement(element, strategy)
   el.get().click()
@@ -44,78 +36,33 @@ proc clear*(session: Session, element: string) =
   let el = session.waitForElement(element)
   el.get().clear()
 
-proc sendKeys*(session: Session, element: string, keys: varargs[Key]) =
+proc sendKeys*(session: Session, element: string, keys: varargs[string, convertKeyRuneString]) =
   let el = session.waitForElement(element)
 
-  # focus
-  el.get().click()
-  for key in keys:
-    session.press(key)
+  el.get().sendKeys(keys)
 
 proc ensureExists*(session: Session, element: string, strategy=CssSelector) =
   discard session.waitForElement(element, strategy)
 
 template check*(session: Session, element: string, function: untyped) =
   let el = session.waitForElement(element)
-  check function(el)
+  doAssert function(el)
 
 template check*(session: Session, element: string,
                 strategy: LocationStrategy, function: untyped) =
   let el = session.waitForElement(element, strategy)
-  check function(el)
+  doAssert function(el)
 
 proc setColor*(session: Session, element, color: string, strategy=CssSelector) =
   let el = session.waitForElement(element, strategy)
-  discard session.execute("arguments[0].setAttribute('value', '" & color & "')", el.get())
+  discard session.executeScript("arguments[0].setAttribute('value', '" & color & "')", el.get())
 
 proc checkIsNone*(session: Session, element: string, strategy=CssSelector) =
   discard session.waitForElement(element, strategy, waitCondition=elementIsNone)
 
 proc checkText*(session: Session, element, expectedValue: string) =
   let el = session.waitForElement(element)
-  check el.get().getText() == expectedValue
-
-proc waitForElement*(
-  session: Session, selector: string, strategy=CssSelector,
-  timeout=20000, pollTime=50,
-  waitCondition=elementIsSome
-): Option[Element] =
-  var waitTime = 0
-
-  when actionDelayMs > 0:
-    sleep(actionDelayMs)
-
-  while true:
-    try:
-      let loading = session.findElement(selector, strategy)
-      if waitCondition(loading):
-        return loading
-    finally:
-      discard
-    sleep(pollTime)
-    waitTime += pollTime
-
-    if waitTime > timeout:
-      doAssert false, "Wait for load time exceeded"
-
-proc waitForElements*(
-  session: Session, selector: string, strategy=CssSelector,
-  timeout=20000, pollTime=50
-): seq[Element] =
-  var waitTime = 0
-
-  when actionDelayMs > 0:
-    sleep(actionDelayMs)
-
-  while true:
-    let loading = session.findElements(selector, strategy)
-    if loading.len > 0:
-      return loading
-    sleep(pollTime)
-    waitTime += pollTime
-
-    if waitTime > timeout:
-      doAssert false, "Wait for load time exceeded"
+  doAssert el.get().text.strip() == expectedValue
 
 proc setUserRank*(session: Session, baseUrl, user, rank: string) =
   with session:

--- a/tests/browsertests/issue181.nim
+++ b/tests/browsertests/issue181.nim
@@ -1,6 +1,6 @@
 import unittest, common
 
-import webdriver
+import halonium
 
 proc test*(session: Session, baseUrl: string) =
   session.navigate(baseUrl)

--- a/tests/browsertests/scenario1.nim
+++ b/tests/browsertests/scenario1.nim
@@ -1,6 +1,6 @@
 import unittest, common
 
-import webdriver
+import halonium
 
 proc test*(session: Session, baseUrl: string) =
   session.navigate(baseUrl)

--- a/tests/browsertests/threads.nim
+++ b/tests/browsertests/threads.nim
@@ -1,6 +1,6 @@
 import unittest, common
 
-import webdriver
+import halonium
 
 let
   userTitleStr = "This is a user thread!"


### PR DESCRIPTION
I created a library called halonium that is the Nim version of s python selenium. It has the ability to use any of the web drivers and handles errors and thread management. I think it makes sense to use it here vs webdriver due to the current situation with Firefox having a bug in version 80 where clicks on popups don't register. 

Since halonium can work with any browser, if the tests don't work on one browser, we can run it on any other one.