### PR TITLE
Support dashes in usernames

### DIFF
--- a/src/utils.nim
+++ b/src/utils.nim
@@ -5,7 +5,7 @@ from times import getTime, utc, format
 # Used to be:
 # {'A'..'Z', 'a'..'z', '0'..'9', '_', '\128'..'\255'}
 let
-  UsernameIdent* = IdentChars # TODO: Double check that everyone follows this.
+  UsernameIdent* = IdentChars + {'-'} # TODO: Double check that everyone follows this.
 
 import frontend/[karaxutils, error]
 export parseInt


### PR DESCRIPTION
By default, nimforum uses `strutils`' `IdentChars` set for determining whether or not a username is valid. The IdentChars set contains `{'a'..'z', 'A'..'Z', '0'..'9', '_'}`, which excludes the commonly-used `-`.

This makes sense for Nim - having the`-` sign available for variables to use would be easily confused with subtracting separate variables. But for usernames, dashes are extremely common - the Nim organization name even contains one! Just about every website / forum I've encountered allows `-` to be used, except this one.

`UsernameIdent` is used very minimally in the codebase, so to the best of my knowledge, this PR _shouldn't_ mess up anything else (unless sql's `collate nocase` messes with dashes).