### PR TITLE
Tests for locking threads

### DIFF
--- a/src/frontend/postbutton.nim
+++ b/src/frontend/postbutton.nim
@@ -190,7 +190,7 @@ when defined(js):
       else: ""
 
     result = buildHtml():
-      button(class="btn btn-secondary",
+      button(class="btn btn-secondary", id="lock-btn",
            onClick=(e: Event, n: VNode) =>
               onLockClick(e, n, state, thread),
            "data-tooltip"=tooltip,

--- a/tests/browsertests/threads.nim
+++ b/tests/browsertests/threads.nim
@@ -71,6 +71,20 @@ proc userTests(session: Session, baseUrl: string) =
 
         checkIsNone "#pin-btn"
 
+    test "cannot lock threads":
+      with session:
+        navigate(baseUrl)
+
+        click "#new-thread-btn"
+
+        sendKeys "#thread-title", "Locking"
+        sendkeys "#reply-textarea", "Cannot lock as an user"
+
+        click "#create-thread-btn"
+
+        checkIsNone "#lock-btn"
+        navigate(baseUrl)
+
     session.logout()
 
 proc anonymousTests(session: Session, baseUrl: string) =
@@ -212,6 +226,20 @@ proc adminTests(session: Session, baseUrl: string) =
         checkText "#threads-list .thread-1 .thread-title a", "Normal post"
         checkText "#threads-list .thread-2 .thread-title a", "Pinned post"
 
+    test "Can lock a thread":
+      with session:
+        click "Locking", LinkTextSelector
+        click "#lock-btn"
+
+        ensureExists "i .fas .fa-lock .fa-xs"
+
+    test "Can unlock a thread":
+      with session:
+        click "Locking", LinkTextSelector       
+        click "#lock-btn"
+
+        checkIsNone "#thread-title i .fas .fa-lock fa-xs"
+
     session.logout()
 
 proc test*(session: Session, baseUrl: string) =
@@ -219,12 +247,12 @@ proc test*(session: Session, baseUrl: string) =
 
   userTests(session, baseUrl)
 
-  banUser(session, baseUrl)
+  # banUser(session, baseUrl)
 
-  bannedTests(session, baseUrl)
-  anonymousTests(session, baseUrl)
+  # bannedTests(session, baseUrl)
+  # anonymousTests(session, baseUrl)
   adminTests(session, baseUrl)
 
-  unBanUser(session, baseUrl)
+  # unBanUser(session, baseUrl)
 
   session.navigate(baseUrl)

--- a/tests/browsertests/threads.nim
+++ b/tests/browsertests/threads.nim
@@ -82,7 +82,6 @@ proc userTests(session: Session, baseUrl: string) =
         click "#create-thread-btn"
 
         checkIsNone "#lock-btn"
-        navigate(baseUrl)
 
     session.logout()
 
@@ -231,6 +230,11 @@ proc adminTests(session: Session, baseUrl: string) =
         click "#lock-btn"
 
         ensureExists "#thread-title i.fas.fa-lock.fa-xs"
+
+        # Our locked thread has to appear locked on the frontpage too
+        navigate(baseUrl)
+
+        ensureExists "#threads-list .thread-3 .thread-title i.fas.fa-lock.fa-xs"
 
     test "can unlock a thread":
       with session:

--- a/tests/browsertests/threads.nim
+++ b/tests/browsertests/threads.nim
@@ -231,10 +231,16 @@ proc adminTests(session: Session, baseUrl: string) =
 
         ensureExists "#thread-title i.fas.fa-lock.fa-xs"
 
-        # Our locked thread has to appear locked on the frontpage too
+    test "locked thread appears on frontpage":
+      with session:
+        click "#new-thread-btn"
+        sendKeys "#thread-title", "A new locked thread"
+        sendKeys "#reply-textarea", "This thread should appear locked on the frontpage"
+        click "#create-thread-btn"
+        click "#lock-btn"
+        
         navigate(baseUrl)
-
-        ensureExists "#threads-list .thread-3 .thread-title i.fas.fa-lock.fa-xs"
+        ensureExists "#threads-list .thread-1 .thread-title i.fas.fa-lock.fa-xs"
 
     test "can unlock a thread":
       with session:

--- a/tests/browsertests/threads.nim
+++ b/tests/browsertests/threads.nim
@@ -247,12 +247,12 @@ proc test*(session: Session, baseUrl: string) =
 
   userTests(session, baseUrl)
 
-  # banUser(session, baseUrl)
+  banUser(session, baseUrl)
 
-  # bannedTests(session, baseUrl)
-  # anonymousTests(session, baseUrl)
+  bannedTests(session, baseUrl)
+  anonymousTests(session, baseUrl)
   adminTests(session, baseUrl)
 
-  # unBanUser(session, baseUrl)
+  unBanUser(session, baseUrl)
 
   session.navigate(baseUrl)

--- a/tests/browsertests/threads.nim
+++ b/tests/browsertests/threads.nim
@@ -187,7 +187,7 @@ proc adminTests(session: Session, baseUrl: string) =
         # Make sure the forum post is gone
         checkIsNone adminTitleStr, LinkTextSelector
 
-    test "Can pin a thread":
+    test "can pin a thread":
       with session:
         click "#new-thread-btn"
         sendKeys "#thread-title", "Pinned post"
@@ -213,7 +213,7 @@ proc adminTests(session: Session, baseUrl: string) =
         checkText "#threads-list .thread-1 .thread-title a", "Pinned post"
         checkText "#threads-list .thread-2 .thread-title a", "Normal post"
 
-    test "Can unpin a thread":
+    test "can unpin a thread":
       with session:
         click "Pinned post", LinkTextSelector
         click "#pin-btn"
@@ -226,14 +226,14 @@ proc adminTests(session: Session, baseUrl: string) =
         checkText "#threads-list .thread-1 .thread-title a", "Normal post"
         checkText "#threads-list .thread-2 .thread-title a", "Pinned post"
 
-    test "Can lock a thread":
+    test "can lock a thread":
       with session:
         click "Locking", LinkTextSelector
         click "#lock-btn"
 
         ensureExists "i .fas .fa-lock .fa-xs"
 
-    test "Can unlock a thread":
+    test "can unlock a thread":
       with session:
         click "Locking", LinkTextSelector       
         click "#lock-btn"

--- a/tests/browsertests/threads.nim
+++ b/tests/browsertests/threads.nim
@@ -1,5 +1,4 @@
 import unittest, common
-
 import webdriver
 
 let
@@ -231,14 +230,14 @@ proc adminTests(session: Session, baseUrl: string) =
         click "Locking", LinkTextSelector
         click "#lock-btn"
 
-        ensureExists "i .fas .fa-lock .fa-xs"
+        ensureExists "#thread-title i.fas.fa-lock.fa-xs"
 
     test "can unlock a thread":
       with session:
         click "Locking", LinkTextSelector       
         click "#lock-btn"
 
-        checkIsNone "#thread-title i .fas .fa-lock fa-xs"
+        checkIsNone "#thread-title i.fas.fa-lock.fa-xs"
 
     session.logout()
 


### PR DESCRIPTION
Even though tests are flaky maybe right now, I'm attempting this.

Current hiccup I'm running into however is selecting the icon or the "Locked" string that happens when you lock a thread not sure what the exact query should be?

```
geckodriver: 1619450393181      webdriver::server       DEBUG   <- 404 Not Found
 {"value":{"error":"no such element","message":"Unable to locate element: i .fas
 .fa-lock .fa-xs","stacktrace":"WebDriverError@chrome://marionette/content/error
.js:181:5\nNoSuchElementError@chrome://marionette/content/error.js:393:5\nelemen
t.find/</<@chrome://marionette/content/element.js:306:16\n"}}
```