### PR TITLE
Fixes a few crashes and search functionality.

### DIFF
--- a/src/forum.nim
+++ b/src/forum.nim
@@ -882,6 +882,8 @@ routes:
             where t.id = ? and isDeleted = 0 and category = c.id;"""
 
     let threadRow = getRow(db, threadsQuery, id)
+    if threadRow[0].len == 0:
+      resp Http404, "Thread not found"
     let thread = selectThread(threadRow, selectThreadAuthor(id))
 
     let postsQuery =
@@ -927,9 +929,11 @@ routes:
 
   get "/specific_posts.json":
     createTFD()
-    var
+    var ids: JsonNode
+    try:
       ids = parseJson(@"ids")
-
+    except JsonParsingError:
+      resp Http400, "Invalid JSON"
     cond ids.kind == JArray
     let intIDs = ids.elems.map(x => x.getInt())
     let postsQuery = sql("""

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -883,7 +883,10 @@ routes:
 
     let threadRow = getRow(db, threadsQuery, id)
     if threadRow[0].len == 0:
-      resp Http404, "Thread not found"
+      let err = PostError(
+        message: "Specified thread does not exist"
+      )
+      resp Http404, $(%err), "application/json"
     let thread = selectThread(threadRow, selectThreadAuthor(id))
 
     let postsQuery =
@@ -933,7 +936,10 @@ routes:
     try:
       ids = parseJson(@"ids")
     except JsonParsingError:
-      resp Http400, "Invalid JSON"
+      let err = PostError(
+        message: "Invalid JSON in the `ids` parameter"
+      )
+      resp Http400, $(%err), "application/json"
     cond ids.kind == JArray
     let intIDs = ids.elems.map(x => x.getInt())
     let postsQuery = sql("""

--- a/src/fts.sql
+++ b/src/fts.sql
@@ -7,6 +7,7 @@ SELECT
         post_id,
         post_content,
         cdate,
+        person.id,
         person.name AS author,
         person.email AS email,
         strftime('%s', person.lastOnline) AS lastOnline,


### PR DESCRIPTION
Search functionality has been broken in nimforum for more than a year - ever since https://github.com/nim-lang/nimforum/commit/4821746c5de151d7c223b75049ba285dd8b1d191#diff-49be0ddcdb5a593739d0f189218d3a03a1af8a069d5c8262d8141bff7269e9ed was merged. There's https://github.com/nim-lang/nimforum/pull/300 but it renames `content` to `post_content` for some reason which is not needed (you can close it after you merge this PR).

I also added checks for two crashes that can happen - both of them for some reason crash the whole Nimforum prod instance, but when running locally you only get an exception.