### PR TITLE
Use quotation support from rst.nim

### DIFF
--- a/src/utils.nim
+++ b/src/utils.nim
@@ -178,8 +178,10 @@ proc rstToHtml*(content: string): string =
                             docConfig)
   try:
     var node = parseHtml(newStringStream(result))
-    if node.kind == xnElement:
-      node = processQuotes(node)
+    # rst.nim parser did not support quotes until Nim 1.7:
+    when (NimMajor, NimMinor) < (1, 7):
+      if node.kind == xnElement:
+        node = processQuotes(node)
     node = processMentions(node)
     result = ""
     add(result, node, indWidth=0, addNewLines=false)


### PR DESCRIPTION
When https://github.com/nim-lang/Nim/pull/19147 is merged use it instead for RST/Markdown block quotes. This is needed to address a (minor) bug mentioned there.