### PR TITLE
bump karax version to include the patch for vnode pollution

### DIFF
--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -20,7 +20,7 @@ requires "hmac#9c61ebe2fd134cf97"
 requires "recaptcha#d06488e"
 requires "sass#649e0701fa5c"
 
-requires "karax#5f21dcd"
+requires "karax#45bac6b"
 
 requires "webdriver#429933a"
 


### PR DESCRIPTION
closes https://github.com/nim-lang/nimforum/issues/303

I have tested locally, it works.

![image](https://user-images.githubusercontent.com/43030857/209176045-2a2ac001-a27d-4e6a-a768-9ab48fb2287a.png)
