### PR TITLE
return raw post rst when rendering fails

### DIFF
--- a/src/forum.nim
+++ b/src/forum.nim
@@ -21,7 +21,7 @@ import frontend/[
   category, postlist, error, header, post, profile, user, karaxutils, search
 ]
 
-from htmlgen import tr, th, td, span, input
+from htmlgen import tr, th, td, span, input, `div`, pre
 
 when not declared(roSandboxDisabled):
   {.error: "Your Nim version is vulnerable to a CVE. Upgrade it.".}
@@ -307,7 +307,10 @@ proc selectPost(postRow: seq[string], skippedPosts: seq[int],
     try:
       postRow[1].rstToHtml()
     except EParseError:
-      span(class="text-error", "Couldn't render post #$1." % postRow[0])
+      `div`(
+        span(class="text-error", "Couldn't render post #$1, raw RST below." % postRow[0]),
+        pre(postRow[1])
+      )
 
   return Post(
     id: postRow[0].parseInt,
@@ -362,7 +365,10 @@ proc selectHistory(postId: int): seq[PostInfo] =
         try:
           row[1].rstToHtml()
         except EParseError:
-          span(class="text-error", "Couldn't render historic post in #$1." % $postId)
+          `div`(
+            span(class="text-error", "Couldn't render historic post #$1, raw RST below." % $postId),
+            pre(row[1])
+          )
     ))
 
 proc selectLikes(postId: int): seq[User] =

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -22,6 +22,7 @@ import frontend/[
 ]
 
 from htmlgen import tr, th, td, span, input, `div`, pre
+from xmltree import escape
 
 when not declared(roSandboxDisabled):
   {.error: "Your Nim version is vulnerable to a CVE. Upgrade it.".}
@@ -309,7 +310,7 @@ proc selectPost(postRow: seq[string], skippedPosts: seq[int],
     except EParseError:
       `div`(
         span(class="text-error", "Couldn't render post #$1, raw RST below." % postRow[0]),
-        pre(postRow[1])
+        pre(xmltree.escape(postRow[1]))
       )
 
   return Post(
@@ -367,7 +368,7 @@ proc selectHistory(postId: int): seq[PostInfo] =
         except EParseError:
           `div`(
             span(class="text-error", "Couldn't render historic post #$1, raw RST below." % $postId),
-            pre(row[1])
+            pre(xmltree.escape(row[1]))
           )
     ))
 


### PR DESCRIPTION
This PR introduces a simple change to show the raw RST text when a post fails to render (as discussed in #330). This should improve the experience when reading older threads where the issue is more prevalent, and improve visibility with search engines that can now pick up the original post content instead of the error message. It's been suggested that recent improvements to the RST parser will reduce the amount of these problematic posts as well.

I have used the content of the first post [from this thread](https://forum.nim-lang.org/t/8754) for testing.

Before:
![image](https://user-images.githubusercontent.com/1889120/212935690-552f0c44-1086-4d20-aa2e-7554b8be6f89.png)
After:
![image](https://user-images.githubusercontent.com/1889120/212935728-62752b56-691f-42bd-bc0c-ee76a544dc2c.png)

I've also tested that embedding the raw post does not allow for js injection.