### PR TITLE
#339 Make the nimforum Nim2 compatible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,5 +68,5 @@ jobs:
         run: |
           export PATH=$HOME/.nimble/bin:$PATH
           export MOZ_HEADLESS=1
-          nimble -y install
+          nimble -y --mm:refc install
           nimble -y test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,14 +12,14 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  test_stable:
+  test_stable_and_devel:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         chrome: [ 'stable' ]
+        nim-version: ['1.6.10', 'devel']
         include:
-          - nim-version: '1.6.10'
-            cache-key: 'stable'
+          - cache-key: 'stable'
     steps:
       - uses: actions/checkout@v2
       - name: Checkout submodules

--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -24,6 +24,9 @@ requires "karax#45bac6b"
 
 requires "webdriver#429933a"
 
+when NimMajor >= 1 and NimMinor >= 9:
+  requires "db_connector >= 0.1.0"
+
 # Tasks
 
 task backend, "Compiles and runs the forum backend":

--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -41,8 +41,7 @@ task testbackend, "Runs the forum backend in test mode":
   exec "nimble c -r --mm:refc -d:skipRateLimitCheck src/forum.nim"
 
 task frontend, "Builds the necessary JS frontend (with CSS)":
-  exec "nimble c -r src/buildcss"
-  exec "nimble js -d:release src/frontend/forum.nim"
+  exec "nimble c -r --mm:refc src/buildcss"
   mkDir "public/js"
   cpFile "src/frontend/forum.js", "public/js/forum.js"
 

--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -26,18 +26,19 @@ requires "webdriver#429933a"
 
 when NimMajor >= 1 and NimMinor >= 9:
   requires "db_connector >= 0.1.0"
+  requires "smtp >= 0.1.0"
 
 # Tasks
 
 task backend, "Compiles and runs the forum backend":
-  exec "nimble c src/forum.nim"
+  exec "nimble c --mm:refc src/forum.nim"
   exec "./src/forum"
 
 task runbackend, "Runs the forum backend":
   exec "./src/forum"
 
 task testbackend, "Runs the forum backend in test mode":
-  exec "nimble c -r -d:skipRateLimitCheck src/forum.nim"
+  exec "nimble c -r --mm:refc -d:skipRateLimitCheck src/forum.nim"
 
 task frontend, "Builds the necessary JS frontend (with CSS)":
   exec "nimble c -r src/buildcss"
@@ -61,7 +62,7 @@ task blankdb, "Creates a blank DB":
   exec "./src/setup_nimforum --blank"
 
 task test, "Runs tester":
-  exec "nimble c -y src/forum.nim"
+  exec "nimble c -y --mm:refc src/forum.nim"
   exec "nimble c -y -r -d:actionDelayMs=0 tests/browsertester"
 
 task fasttest, "Runs tester without recompiling backend":

--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -22,7 +22,7 @@ requires "sass#649e0701fa5c"
 
 requires "karax#45bac6b"
 
-requires "webdriver#429933a"
+requires "webdriver#c5e4182"
 
 when NimMajor >= 1 and NimMinor >= 9:
   requires "db_connector >= 0.1.0"

--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -42,6 +42,7 @@ task testbackend, "Runs the forum backend in test mode":
 
 task frontend, "Builds the necessary JS frontend (with CSS)":
   exec "nimble c -r --mm:refc src/buildcss"
+  exec "nimble js -d:release src/frontend/forum.nim"
   mkDir "public/js"
   cpFile "src/frontend/forum.js", "public/js/forum.js"
 

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -7,14 +7,19 @@
 #
 import system except Thread
 import
-  os, strutils, times, md5, strtabs, math, db_sqlite,
+  os, strutils, times, md5, strtabs, math,
   jester, asyncdispatch, asyncnet, sequtils,
   parseutils, random, rst, recaptcha, json, re, sugar,
   strformat, logging
 import cgi except setCookie
-import options
+import std/options
 
 import auth, email, utils, buildcss
+
+when NimMajor >= 1 and NimMinor >= 9:
+  import db_connector/db_sqlite
+else:
+  import std/db_sqlite
 
 import frontend/threadlist except User
 import frontend/[

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -85,22 +85,23 @@ proc getGravatarUrl(email: string, size = 80): string =
 
 # -----------------------------------------------------------------------------
 
-proc validateCaptcha(recaptchaResp, ip: string) {.async.} =
+proc validateCaptcha(recaptchaResp, ip: string) {.async, gcsafe.} =
   # captcha validation:
-  if config.recaptchaSecretKey.len > 0:
-    var verifyFut = captcha.verify(recaptchaResp, ip)
-    yield verifyFut
-    if verifyFut.failed:
-      raise newForumError(
-        "Invalid recaptcha answer", @[]
-      )
+  {.cast(gcsafe).}:
+    if config.recaptchaSecretKey.len > 0:
+      var verifyFut = captcha.verify(recaptchaResp, ip)
+      yield verifyFut
+      if verifyFut.failed:
+        raise newForumError(
+          "Invalid recaptcha answer", @[]
+        )
 
 proc sendResetPassword(
   c: TForumData,
   email: string,
   recaptchaResp: string,
   userIp: string
-) {.async.} =
+) {.async, gcsafe.} =
   # Gather some extra information to determine ident hash.
   let row = db.getRow(
     sql"""
@@ -112,14 +113,15 @@ proc sendResetPassword(
   if row[0] == "":
     raise newForumError("Email or username not found", @["email"])
 
-  if not c.loggedIn:
-    await validateCaptcha(recaptchaResp, userIp)
+  {.cast(gcsafe).}:
+    if not c.loggedIn:
+      await validateCaptcha(recaptchaResp, userIp)
 
-  await sendSecureEmail(
-    mailer,
-    ResetPassword, c.req,
-    row[0], row[1], row[2], row[3]
-  )
+    await sendSecureEmail(
+      mailer,
+      ResetPassword, c.req,
+      row[0], row[1], row[2], row[3]
+    )
 
 proc logout(c: TForumData) =
   const query = sql"delete from session where key = ?"
@@ -180,7 +182,7 @@ proc incrementViews(threadId: int) =
   const query = sql"update thread set views = views + 1 where id = ?"
   exec(db, query, threadId)
 
-proc validateRst(c: TForumData, content: string): bool =
+proc validateRst(c: TForumData, content: string): bool {.gcsafe.}=
   result = true
   try:
     discard rstToHtml(content)
@@ -443,7 +445,7 @@ proc selectThread(threadRow: seq[string], author: User): Thread =
   return thread
 
 proc executeReply(c: TForumData, threadId: int, content: string,
-                  replyingTo: Option[int]): int64 =
+                  replyingTo: Option[int]): int64 {.gcsafe.} =
   # TODO: Refactor TForumData.
   assert c.loggedIn()
 
@@ -558,7 +560,7 @@ proc updateThread(c: TForumData, threadId: string, queryKeys: seq[string], query
 
   exec(db, crud(crUpdate, "thread", queryKeys), queryValues)
 
-proc executeNewThread(c: TForumData, subject, msg, categoryID: string): (int64, int64) =
+proc executeNewThread(c: TForumData, subject, msg, categoryID: string): (int64, int64) {.gcsafe.} =
   const
     query = sql"""
       insert into thread(name, views, modified, category) values (?, 0, DATETIME('now'), ?)
@@ -640,7 +642,7 @@ proc validateEmail(email: string, checkDuplicated: bool) =
       raise newForumError("Email already exists", @["email"])
 
 proc executeRegister(c: TForumData, name, pass, antibot, userIp,
-                     email: string) {.async.} =
+                     email: string) {.async, gcsafe.} =
   ## Registers a new user.
 
   # email validation
@@ -667,9 +669,10 @@ proc executeRegister(c: TForumData, name, pass, antibot, userIp,
   let password = makePassword(pass, salt)
 
   # Send activation email.
-  await sendSecureEmail(
-    mailer, ActivateEmail, c.req, name, password, email, salt
-  )
+  {.cast(gcsafe).}:
+    await sendSecureEmail(
+      mailer, ActivateEmail, c.req, name, password, email, salt
+    )
 
   # Add account to person table
   exec(db, sql"""
@@ -773,7 +776,7 @@ proc executeDeleteUser(c: TForumData, username: string) =
 
 proc updateProfile(
   c: TForumData, username, email: string, rank: Rank
-) {.async.} =
+) {.async, gcsafe.} =
   if c.rank < rank:
     raise newForumError("You cannot set a rank that is higher than yours.")
 
@@ -799,10 +802,11 @@ proc updateProfile(
   if c.rank < Moderator and wasEmailChanged:
     if rank != EmailUnconfirmed:
       raise newForumError("Rank needs a change when setting new email.")
-
-    await sendSecureEmail(
-      mailer, ActivateEmail, c.req, row[0], row[1], email, row[3]
-    )
+    
+    {.cast(gcsafe).}:
+      await sendSecureEmail(
+        mailer, ActivateEmail, c.req, row[0], row[1], email, row[3]
+      )
 
   validateEmail(email, checkDuplicated=wasEmailChanged)
 
@@ -860,9 +864,9 @@ routes:
 
     const threadsQuery =
       """select t.id, t.name, views, strftime('%s', modified), isLocked, isPinned,
-                   c.id, c.name, c.description, c.color,
-                   u.id, u.name, u.email, strftime('%s', u.lastOnline),
-                   strftime('%s', u.previousVisitAt), u.status, u.isDeleted
+                  c.id, c.name, c.description, c.color,
+                  u.id, u.name, u.email, strftime('%s', u.lastOnline),
+                  strftime('%s', u.previousVisitAt), u.status, u.isDeleted
             from thread t, category c, person u
             where t.isDeleted = 0 and category = c.id and $#
                   u.status <> 'Spammer' and u.status <> 'Troll' and
@@ -895,7 +899,7 @@ routes:
 
     const threadsQuery =
       sql"""select t.id, t.name, views, strftime('%s', modified), isLocked, isPinned,
-                   c.id, c.name, c.description, c.color
+                  c.id, c.name, c.description, c.color
             from thread t, category c
             where t.id = ? and isDeleted = 0 and category = c.id;"""
 
@@ -914,9 +918,9 @@ routes:
                   u.id, u.name, u.email, strftime('%s', u.lastOnline),
                   strftime('%s', u.previousVisitAt), u.status,
                   u.isDeleted
-           from post p, person u
-           where u.id = p.author and p.thread = ? and p.isDeleted = 0
-           order by p.id"""
+          from post p, person u
+          where u.id = p.author and p.thread = ? and p.isDeleted = 0
+          order by p.id"""
       )
 
     var list = PostList(
@@ -962,10 +966,10 @@ routes:
     let intIDs = ids.elems.map(x => x.getInt())
     let postsQuery = sql("""
       select p.id, p.content, strftime('%s', p.creation), p.author,
-             p.replyingTo,
-             u.id, u.name, u.email, strftime('%s', u.lastOnline),
-             strftime('%s', u.previousVisitAt), u.status,
-             u.isDeleted
+            p.replyingTo,
+            u.id, u.name, u.email, strftime('%s', u.lastOnline),
+            strftime('%s', u.previousVisitAt), u.status,
+            u.isDeleted
       from post p, person u
       where u.id = p.author and p.id in ($#)
       order by p.id;
@@ -1010,8 +1014,8 @@ routes:
     # TODO: Figure out a better way. This is horrible.
     let creatorSubquery = """
         (select $1 from post p
-         where p.thread = t.id
-         order by p.id asc limit 1)
+        where p.thread = t.id
+        order by p.id asc limit 1)
     """
 
     let threadsFrom = """
@@ -1026,15 +1030,15 @@ routes:
 
     let postsQuery = sql("""
       select p.id, strftime('%s', p.creation),
-             t.name, t.id
+            t.name, t.id
       $1
       order by p.id desc limit 10;
     """ % postsFrom)
 
     let userQuery = sql("""
       select id, name, email, strftime('%s', lastOnline),
-             strftime('%s', previousVisitAt), status, isDeleted,
-             strftime('%s', creation), id
+            strftime('%s', previousVisitAt), status, isDeleted,
+            strftime('%s', creation), id
       from person
       where name = ? and isDeleted = 0
     """)
@@ -1107,8 +1111,9 @@ routes:
   post "/signup":
     createTFD()
     let formData = request.formData
-    if not config.isDev:
-      cond "g-recaptcha-response" in formData
+    {.cast(gcsafe).}:
+      if not config.isDev:
+        cond "g-recaptcha-response" in formData
 
     let username = formData["username"].body
     let password = formData["password"].body
@@ -1163,16 +1168,16 @@ routes:
         ))
       else:
         none[User]()
-
-    let status = UserStatus(
-      user: user,
-      recaptchaSiteKey:
-        if not config.isDev:
-          some(config.recaptchaSiteKey)
-        else:
-          none[string]()
-    )
-    resp $(%status), "application/json"
+    {.cast(gcsafe).}:
+      let status = UserStatus(
+        user: user,
+        recaptchaSiteKey:
+          if not config.isDev:
+            some(config.recaptchaSiteKey)
+          else:
+            none[string]()
+      )
+      resp $(%status), "application/json"
 
   post "/preview":
     createTFD()
@@ -1194,7 +1199,7 @@ routes:
       let err = PostError(
         errorFields: @[],
         message: "Message needs to be valid RST! Error: " &
-                 getCurrentExceptionMsg()
+                getCurrentExceptionMsg()
       )
       resp Http400, $(%err), "application/json"
 
@@ -1484,7 +1489,9 @@ routes:
         ""
 
     if not c.loggedIn():
-      if not config.isDev:
+      {.cast(gcsafe).}:
+        let isProductionEnvironment = not config.isDev
+      if isProductionEnvironment:
         if "g-recaptcha-response" notin formData:
           let err = PostError(
             errorFields: @[],
@@ -1591,12 +1598,13 @@ routes:
     resp Http404, readFile("public/karax.html")
 
   get "/about/license.html":
-    let content = readFile("public/license.rst") %
-      {
-        "hostname": config.hostname,
-        "name": config.name
-      }.newStringTable()
-    resp content.rstToHtml()
+    {.cast(gcsafe).}:
+      let content = readFile("public/license.rst") %
+        {
+          "hostname": config.hostname,
+          "name": config.name
+        }.newStringTable()
+      resp content.rstToHtml()
 
   get "/about/rst.html":
     let content = readFile("public/rst.rst")
@@ -1604,11 +1612,13 @@ routes:
 
   get "/threadActivity.xml":
     createTFD()
-    resp genThreadsRSS(c), "application/atom+xml"
+    {.cast(gcsafe).}:
+      resp genThreadsRSS(c), "application/atom+xml"
 
   get "/postActivity.xml":
     createTFD()
-    resp genPostsRSS(c), "application/atom+xml"
+    {.cast(gcsafe).}:
+      resp genPostsRSS(c), "application/atom+xml"
 
   get "/search.json":
     cond "q" in request.params
@@ -1642,4 +1652,5 @@ routes:
 
   get re"/(.*)":
     cond request.matches[0].splitFile.ext == ""
-    resp karaxHtml
+    {.cast(gcsafe).}:
+      resp karaxHtml

--- a/src/importer.nim
+++ b/src/importer.nim
@@ -1,5 +1,9 @@
-import db_sqlite, strutils
-
+import strutils
+when NimMajor >= 1 and NimMinor >= 9:
+  import db_connector/db_sqlite
+else:
+  import std/db_sqlite
+  
 let origFile = "nimforum.db-21-05-18"
 let targetFile = "nimforum-blank.db"
 

--- a/src/setup_nimforum.nim
+++ b/src/setup_nimforum.nim
@@ -7,7 +7,12 @@
 #
 # Script to initialise the nimforum.
 
-import strutils, db_sqlite, os, times, json, options, terminal
+import strutils, os, times, json, options, terminal
+
+when NimMajor >= 1 and NimMinor >= 9:
+  import db_connector/db_sqlite
+else:
+  import std/db_sqlite
 
 import auth, frontend/user
 

--- a/src/setup_nimforum.nim
+++ b/src/setup_nimforum.nim
@@ -386,4 +386,4 @@ when isMainModule:
   else:
     echoHelp()
 
-
+  quit()

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -173,9 +173,10 @@ proc processMentions(node: XmlNode): XmlNode =
   else:
     return node
 
-proc rstToHtml*(content: string): string =
-  result = rstgen.rstToHtml(content, {roSupportMarkdown},
-                            docConfig)
+proc rstToHtml*(content: string): string {.gcsafe.}=
+  {.cast(gcsafe).}:
+    result = rstgen.rstToHtml(content, {roSupportMarkdown},
+                              docConfig)
   try:
     var node = parseHtml(newStringStream(result))
     # rst.nim parser did not support quotes until Nim 1.7:


### PR DESCRIPTION
The PR corresponding to issue #339, which should close it.

The changes provided in here were what was needed to get the tests (as executed via `nimble test`) to run locally while using the following nim version:

```txt
Nim Compiler Version 1.9.1 [Linux: amd64]
Compiled at 2022-12-22
Copyright (c) 2006-2022 by Andreas Rumpf

git hash: d0721eadf8cd6bf9436b5e5c9113c4c7bcfcc770
active boot switches: -d:release
```

The changes at large were mostly:

- Circumvent gc-safety checks of the compiler (I assume the checks have gotten stricter?) using cast(gcsafe)
- Move back to use refc instead of ORC in the nimble tasks. Using ORC leads to hard to debug error messages from within the C code that I don't really know how to deal with. As it worked previously fine under refc, I moved back to that. 
- Adjust Imports of smtp and db_sqlite since they are no longer part of the std lib
- Adding "quit()" to the `nimble testdb` task to **force** the task to return with exitCode 0. Previously it returned... some sort of number depending on the amount of text echo'd out. That lead to the test-task being unable to get past it as it interpreted that exitCode (as per the default specs of `exec`)  to be an error 