### PR TITLE
fix certain version checks

### DIFF
--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -24,7 +24,7 @@ requires "karax#45bac6b"
 
 requires "webdriver#c5e4182"
 
-when NimMajor >= 1 and NimMinor >= 9:
+when NimMajor > 1:
   requires "db_connector >= 0.1.0"
   requires "smtp >= 0.1.0"
 

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -16,7 +16,7 @@ import std/options
 
 import auth, email, utils, buildcss
 
-when NimMajor >= 1 and NimMinor >= 9:
+when NimMajor > 1:
   import db_connector/db_sqlite
 else:
   import std/db_sqlite

--- a/src/importer.nim
+++ b/src/importer.nim
@@ -1,5 +1,5 @@
 import strutils
-when NimMajor >= 1 and NimMinor >= 9:
+when NimMajor > 1:
   import db_connector/db_sqlite
 else:
   import std/db_sqlite

--- a/src/setup_nimforum.nim
+++ b/src/setup_nimforum.nim
@@ -9,7 +9,7 @@
 
 import strutils, os, times, json, options, terminal
 
-when NimMajor >= 1 and NimMinor >= 9:
+when NimMajor > 1:
   import db_connector/db_sqlite
 else:
   import std/db_sqlite


### PR DESCRIPTION
Nimforum is completely broken for me, trying to compile/run it through nim 2.0.0.

## Symptom

```
me@mymachine ~ $ git clone https://github.com/nim-lang/nimforum.git nimforum-orig
[...]
me@mymachine ~ $ cd nimforum-orig
me@mymachine ~/nimforum-orig $ git submodule update --init --recursive
[...]
me@mymachine ~/nimforum-orig $
me@mymachine ~/nimforum-orig $ nimble devdb
[...]
  Compiling src/setup_nimforum (from package nimforum) using c backend
/home/pay/nimforum-orig/src/setup_nimforum.nim(15, 13) Error: cannot open file: std/db_sqlite
       Tip: 34 messages have been suppressed, use --verbose to show them.
tools.nim(36)            doCmd

    Error:  Execution failed with exit code 1
        ... Command: /home/rfsoft/.rfsoft/nim-2.0.0/bin/nim c --noNimblePath -d:NimblePkgVersion=2.2.0 --path:/home/pay/.nimble/pkgs2/asynctools-0.1.1-5e7df4178ee5c148532ff8c44a22015d576624d8 --path:/home/pay/.nimble/pkgs2/webdriver-0.2.0-ae36fdd5d717345006969a795f421147d8ff1883 --path:/home/pay/.nimble/pkgs2/bcrypt-0.2.1-5d8719a26c03137b6c38dbf13e9a102b985f8d18 --path:/home/pay/.nimble/pkgs2/hmac-0.1.5-e10a18fe2b88ac8f052d03d3f0896a2dd6fbb3d2 --path:/home/pay/.nimble/pkgs2/karax-1.2.2-811f1a29038c95b2438609a474be6fbd3bdc217c --path:/home/pay/.nimble/pkgs2/jester-0.4.3-57773c731761f05eefa87259f19952d068de93e3 --path:/home/pay/.nimble/pkgs2/nimSHA2-0.1.1-6765d9a04c328c64eb56b3fa90f45690294cc8fd --path:/home/pay/.nimble/pkgs2/dotenv-2.0.1-9a9e39544f129e6666935796610da79fbe724510 --path:/home/pay/.nimble/pkgs2/sass-0.1.0-c71feb4a550644f9c1b4a84cced99d714bbc7de7 --path:/home/pay/.nimble/pkgs2/sha1-1.1-2610d27cf248adf98fd9b86e906eb87781ba9d8c --path:/home/pay/.nimble/pkgs2/httpbeast-0.4.1-b23e57a401057dcb9b7fae1fb8279a6a2ce1d0b8 --path:/home/pay/.nimble/pkgs2/ws-0.5.0-ae4daf4ae302d0431f3c2d385ae9d2fe767a3246 --path:/home/pay/.nimble/pkgs2/recaptcha-1.0.3-3c546c0c85dd0280b22db13cacc7d6eafed28d86 --path:/home/pay/.nimble/pkgs2/asynctools-0.1.1-54314dceabb06b20908ecb0f2c007e9ff3aaa054 --hints:off src/setup_nimforum
stack trace: (most recent call last)
/tmp/nimblecache-948311561/nimscriptapi_3224943245.nim(210, 16)
/home/pay/nimforum-orig/nimforum.nimble(57, 3) devdbTask
/home/rfsoft/.rfsoft/nim-2.0.0/lib/system/nimscript.nim(265, 7) exec
/home/rfsoft/.rfsoft/nim-2.0.0/lib/system/nimscript.nim(265, 7) Error: unhandled exception: FAILED: nimble c src/setup_nimforum [OSError]
       Tip: 34 messages have been suppressed, use --verbose to show them.
nimscriptwrapper.nim(160) execScript

    Error:  Exception raised during nimble script execution
me@mymachine ~/nimforum-orig $
```

## Solution

It seems to me that some version checks are at fault that have come in through a recently-merged PR (#339).

I would expect that the check for `NimMinor >= 9` would fail for version `2.0.0`.  After changing the check to something that makes more sense to me, the error disappeared.