### PR TITLE
Implement #317 (Show forum version on webpages)

### DIFF
--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -30,8 +30,15 @@ when NimMajor > 1:
 
 # Tasks
 
+var
+  commit = ""
+  commitCmd = gorgeEx("git rev-parse HEAD^")
+
+if commitCmd[1] == 0:
+  commit = commitCmd[0]
+
 task backend, "Compiles and runs the forum backend":
-  exec "nimble c --mm:refc src/forum.nim"
+  exec "nimble c -d:Commit=\"" & commit & "\" -d:Version=\"" & version & "\" --mm:refc src/forum.nim"
   exec "./src/forum"
 
 task runbackend, "Runs the forum backend":
@@ -42,7 +49,7 @@ task testbackend, "Runs the forum backend in test mode":
 
 task frontend, "Builds the necessary JS frontend (with CSS)":
   exec "nimble c -r --mm:refc src/buildcss"
-  exec "nimble js -d:release src/frontend/forum.nim"
+  exec "nimble js -d:Commit=\"" & commit & "\" -d:Version=\"" & version & "\" -d:release src/frontend/forum.nim"
   mkDir "public/js"
   cpFile "src/frontend/forum.js", "public/js/forum.js"
 

--- a/public/karax.html
+++ b/public/karax.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="/css/nimforum.css">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.12/css/all.css" integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9" crossorigin="anonymous">
   <link rel="icon" href="/images/favicon.png">
+  <meta name="generator" content="Nimforum $version - $commit">
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=$ga"></script>

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -278,6 +278,8 @@ proc initialise() =
     {
       "title": config.title,
       "timestamp": encodeUrl(CompileDate & CompileTime),
+      "version": Version,
+      "commit": Commit,
       "ga": config.ga
     }.newStringTable()
 


### PR DESCRIPTION
This commit allows nimforum to embed the version and the specific commit of a particular build into its webpages.
The version info is added at compile-time, through the use of the `{.strdefine.}` pragma. We do need git for the commit hash, but it's not a requirement for compiling nimforum, since it will just default to "" if git doesn't exist or if git returns an error.

The embedded version info is present through this meta tag:
```html
  <meta name="generator" content="Nimforum $version - $commit">
```

Edit: Should've added that this implements #317 (I forgot that GitHub doesn't add links to the titles)

