### PR TITLE
Implement #317 (Show forum version on webpages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ nimcache/
 forum
 createdb
 editdb
+embedinfo
 
 .vscode
 forum.json*
@@ -21,3 +22,4 @@ buildcss
 nimforum.css
 
 /src/frontend/forum.js
+public/karax.ver.html

--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -30,8 +30,15 @@ when NimMajor > 1:
 
 # Tasks
 
+var
+  commit = ""
+  commitCmd = gorgeEx("git rev-parse HEAD^")
+
+if commitCmd[1] == 0:
+  commit = commitCmd[0]
+
 task backend, "Compiles and runs the forum backend":
-  exec "nimble c --mm:refc src/forum.nim"
+  exec "nimble c -d:Commit=\"" & commit & "\" -d:Version=\"" & version & "\" --mm:refc src/forum.nim"
   exec "./src/forum"
 
 task runbackend, "Runs the forum backend":
@@ -42,7 +49,7 @@ task testbackend, "Runs the forum backend in test mode":
 
 task frontend, "Builds the necessary JS frontend (with CSS)":
   exec "nimble c -r --mm:refc src/buildcss"
-  exec "nimble js -d:release src/frontend/forum.nim"
+  exec "nimble js -d:Commit=\"" & commit & "\" -d:Version=\"" & version & "\" -d:release src/frontend/forum.nim"
   mkDir "public/js"
   cpFile "src/frontend/forum.js", "public/js/forum.js"
 

--- a/public/karax.html
+++ b/public/karax.html
@@ -11,7 +11,6 @@
   <link rel="stylesheet" href="/css/nimforum.css">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.12/css/all.css" integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9" crossorigin="anonymous">
   <link rel="icon" href="/images/favicon.png">
-  <meta name="generator" content="Nimforum $version - $commit">
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=$ga"></script>

--- a/public/karax.html
+++ b/public/karax.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="/css/nimforum.css">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.12/css/all.css" integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9" crossorigin="anonymous">
   <link rel="icon" href="/images/favicon.png">
+  <meta name="generator" content="Nimforum $version - $commit">
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=$ga"></script>

--- a/src/embedinfo.nim
+++ b/src/embedinfo.nim
@@ -1,0 +1,28 @@
+# This program inserts whatever command line parameters it receives
+# in a <meta> generator tag in karax.html
+# Each parameter is separated by a dash in the <meta> tag.
+
+# So, `embedinfo Version GitCommit`
+# Will result in `<meta name="generator" content="Nimforum Version - GitCommit">`
+# being added to public/karax.html right after the </title> tag
+import std/[os, strutils]
+
+if paramCount() == 0:
+  quit("Usage: embedinfo [Version] (Commit)")
+
+# Open public/karax.html and loop over every line
+# If the line has an ending <title> tag then we insert
+# our HTML after it.
+var output = ""
+for line in readFile("public/karax.html").splitLines:
+  output.add(line & "\n")
+
+  if "</title>" in line:
+    output.add("  <meta name=\"generator\" content=\"Nimforum ")
+    for param in commandLineParams():
+      output.add(param & " - ")
+    output = output[0..^4] # Remove last dash
+    output.add("\">")
+
+# Write everything into a new file.
+writeFile("public/karax.ver.html", output)

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -45,11 +45,6 @@ type
     userid: string
     config: Config
 
-const
-  # These are supplied by nimble at compile-time
-  # Admittedly, it's a bit hacky but it'll do.
-  Version* {.strdefine.}: string = "0.0.0"
-  Commit* {.strdefine.}: string = ""
 
 var
   db: DbConn
@@ -280,12 +275,15 @@ proc initialise() =
   buildCSS(config)
 
   # Read karax.html and set its properties.
-  karaxHtml = readFile("public/karax.html") %
+  when defined(versioned):
+    karaxHtml = readFile("public/karax.ver.html")
+  else:
+    karaxHtml = readFile("public/karax.html")
+
+  karaxHtml = karaxHtml %
     {
       "title": config.title,
       "timestamp": encodeUrl(CompileDate & CompileTime),
-      "version": Version,
-      "commit": Commit,
       "ga": config.ga
     }.newStringTable()
 

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -45,6 +45,12 @@ type
     userid: string
     config: Config
 
+const
+  # These are supplied by nimble at compile-time
+  # Admittedly, it's a bit hacky but it'll do.
+  Version* {.strdefine.}: string = "0.0.0"
+  Commit* {.strdefine.}: string = ""
+
 var
   db: DbConn
   isFTSAvailable: bool
@@ -278,6 +284,8 @@ proc initialise() =
     {
       "title": config.title,
       "timestamp": encodeUrl(CompileDate & CompileTime),
+      "version": Version,
+      "commit": Commit,
       "ga": config.ga
     }.newStringTable()
 


### PR DESCRIPTION
This commit allows nimforum to embed the version and the specific commit of a particular build into its webpages.
The version info is added at compile-time, through the use of the `{.strdefine.}` pragma. We do need git for the commit hash, but it's not a requirement for compiling nimforum, since it will just default to "" if git doesn't exist or if git returns an error.

The embedded version info is present through this meta tag:
```html
  <meta name="generator" content="Nimforum $version - $commit">
```

Edit: Should've added that this implements #317 (I forgot that GitHub doesn't add links to the titles)

