### PR TITLE
encode newPassword *properly* in the password reset form

### DIFF
--- a/src/frontend/resetpassword.nim
+++ b/src/frontend/resetpassword.nim
@@ -1,5 +1,5 @@
 when defined(js):
-  import sugar, httpcore, options, json
+  import sugar, httpcore, options, json, uri
   import dom except Event, KeyboardEvent
   import jsffi except `&`
 
@@ -36,7 +36,7 @@ when defined(js):
     state.loading = true
     state.error = none[PostError]()
 
-    let uri = makeUri("resetPassword", ("newPassword", $state.newPassword))
+    let uri = makeUri("resetPassword", ("newPassword", encodeUrl($state.newPassword)))
     ajaxPost(uri, @[], "",
              (s: int, r: kstring) => onPost(s, r, state))
 


### PR DESCRIPTION
This commit fixes #374 by calling `encodeUrl` from `std/uri` on the password before sending the request. In my own testing, I was able to use pretty much every problematic character from the issue report, but I think this should be tested more by different people. (I can't believe it was *this simple* to fix, surely there's a catch...)

This fix is not the most ideal one, it would be best if someone re-wrote the code to submit the new password using multipart, I tried writing this fix but I got mysterious errors and gave up.