### PR TITLE
Fix CI test runner by adding missing libpcre3-dev dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install geckodriver
         run: |
           sudo apt-get -qq update
-          sudo apt-get install autoconf libtool libsass-dev
+          sudo apt-get install autoconf libtool libsass-dev libpcre3-dev
           wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz
           mkdir geckodriver
           tar -xzf geckodriver-v0.32.0-linux64.tar.gz -C geckodriver


### PR DESCRIPTION
PRs recently are failing due to nimforum not being able to find `libpcre3.so` shared library, so this commit adds the `libpcre3-dev` to the Actions workflow to fix that problem.