### PR TITLE
Add stopforumspam check and automatic banning

### DIFF
--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -19,6 +19,7 @@ requires "bcrypt#440c5676ff6"
 requires "hmac#9c61ebe2fd134cf97"
 requires "recaptcha#d06488e"
 requires "sass#649e0701fa5c"
+requires "checksums#f8f6bd3"
 
 requires "karax#45bac6b"
 

--- a/src/auth.nim
+++ b/src/auth.nim
@@ -1,4 +1,5 @@
-import md5, std/sysrand
+import std/sysrand
+import checksums/md5
 
 import bcrypt, hmac
 

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -610,7 +610,7 @@ proc executeNewThread(c: TForumData, subject, msg, categoryID: string): (int64, 
     if c.rank == Moderated:
       let
         client = newHttpClient()
-        resp = client.get("http://api.stopforumspam.org/api?emailhash=" & c.email.getMd5 & "&json")
+        resp = client.get("https://api.stopforumspam.org/api?emailhash=" & c.email.getMd5 & "&json")
       if resp.code == Http200:
         let jresp = resp.body.parseJson
         if jresp["success"].num == 1 and jresp["emailhash"].hasKey("confidence") and jresp["emailhash"]["confidence"].fnum > 0.0:
@@ -897,7 +897,7 @@ routes:
             from thread t, category c, person u
             where t.isDeleted = 0 and category = c.id and $#
                   u.status <> 'Spammer' and u.status <> 'Troll' and
-                  u.status <> 'AutoSpammer' and u.status <> 'Banned' and
+                  u.status <> 'AutoSpammer' and
                   u.id = (
                     select p.author from post p
                     where p.thread = t.id

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -48,6 +48,8 @@ type
     userid: string
     config: Config
 
+const supportUrl {.strdefine.} = ""
+
 var
   db: DbConn
   isFTSAvailable: bool
@@ -617,7 +619,7 @@ proc executeNewThread(c: TForumData, subject, msg, categoryID: string): (int64, 
             sql"update person set status = ? where name = ?;",
             AutoSpammer, c.userName
           )
-          raise newForumError("Your account has been marked by https://www.stopforumspam.com/. If you believe this is a mistake please contact a moderator.")
+          raise newForumError("Your account has been marked by https://www.stopforumspam.com/. If you believe this is a mistake please contact a moderator. " & supportUrl)
 
   result[0] = tryInsertID(db, query, subject, categoryID).int
   if result[0] < 0:

--- a/src/forum.nim
+++ b/src/forum.nim
@@ -7,12 +7,13 @@
 #
 import system except Thread
 import
-  os, strutils, times, md5, strtabs, math,
+  os, strutils, times, strtabs, math,
   jester, asyncdispatch, asyncnet, sequtils,
   parseutils, random, rst, recaptcha, json, re, sugar,
   strformat, logging, xmltree
 import cgi except setCookie
 import std/options
+import checksums/md5
 
 import auth, email, utils, buildcss
 
@@ -20,6 +21,8 @@ when NimMajor > 1:
   import db_connector/db_sqlite
 else:
   import std/db_sqlite
+when not defined(skipStopForumSpamCheck):
+  import httpclient
 
 import frontend/threadlist except User
 import frontend/[
@@ -282,8 +285,8 @@ proc initialise() =
     }.newStringTable()
 
 
-template createTFD() =
-  var c {.inject.}: TForumData
+template createTFD() {.dirty.} =
+  var c: TForumData
   new(c)
   init(c)
   c.req = request
@@ -601,6 +604,21 @@ proc executeNewThread(c: TForumData, subject, msg, categoryID: string): (int64, 
     if rateLimitCheck(c):
       raise newForumError("You're posting too fast!")
 
+  when not defined(skipStopForumSpamCheck):
+    if c.rank == Moderated:
+      let
+        client = newHttpClient()
+        resp = client.get("http://api.stopforumspam.org/api?emailhash=" & c.email.getMd5 & "&json")
+      if resp.code == Http200:
+        let jresp = resp.body.parseJson
+        if jresp["success"].num == 1 and jresp["emailhash"].hasKey("confidence") and jresp["emailhash"]["confidence"].fnum > 0.0:
+          exec(
+            db,
+            sql"update person set status = ? where name = ?;",
+            AutoSpammer, c.userName
+          )
+          raise newForumError("Your account has been marked by https://www.stopforumspam.com/. If you believe this is a mistake please contact a moderator.")
+
   result[0] = tryInsertID(db, query, subject, categoryID).int
   if result[0] < 0:
     raise newForumError("Subject already exists", @["subject"])
@@ -877,6 +895,7 @@ routes:
             from thread t, category c, person u
             where t.isDeleted = 0 and category = c.id and $#
                   u.status <> 'Spammer' and u.status <> 'Troll' and
+                  u.status <> 'AutoSpammer' and u.status <> 'Banned' and
                   u.id = (
                     select p.author from post p
                     where p.thread = t.id
@@ -944,12 +963,13 @@ routes:
       let addDetail = i < count or rows.len-i < count or id == anchor
 
       if addDetail:
-        let replyingTo = selectReplyingTo(rows[i][4])
-        let history = selectHistory(id)
-        let likes = selectLikes(id)
-        let post = selectPost(
-          rows[i], skippedPosts, replyingTo, history, likes
-        )
+        let
+          replyingTo = selectReplyingTo(rows[i][4])
+          history = selectHistory(id)
+          likes = selectLikes(id)
+          post = selectPost(
+            rows[i], skippedPosts, replyingTo, history, likes
+          )
         list.posts.add(post)
         skippedPosts = @[]
       else:

--- a/src/frontend/profilesettings.nim
+++ b/src/frontend/profilesettings.nim
@@ -100,7 +100,7 @@ when defined(js):
           text "Your rank determines the actions you can perform " &
                "on the forum."
         case state.rank:
-        of Spammer, Troll:
+        of bannedRanks:
           p(class="form-input-hint text-warning"):
             text "Your account was banned."
         of EmailUnconfirmed:

--- a/src/frontend/user.nim
+++ b/src/frontend/user.nim
@@ -3,6 +3,7 @@ import times, options
 type
   # If you add more "Banned" states, be sure to modify forum's threadsQuery too.
   Rank* {.pure.} = enum ## serialized as 'status'
+    AutoSpammer      ## Account automatically marked as spammer
     Spammer          ## spammer: every post is invisible
     Moderated        ## new member: posts manually reviewed before everybody
                      ## can see them
@@ -25,6 +26,8 @@ type
     rank*: Rank
     isDeleted*: bool
 
+const bannedRanks* = {AutoSpammer, Spammer, Troll, Banned}
+
 proc isOnline*(user: User): bool =
   return getTime().toUnix() - user.lastOnline < (60*5)
 
@@ -39,7 +42,7 @@ proc canPost*(rank: Rank): bool =
   rank >= Rank.User or rank == Moderated
 
 proc isBanned*(rank: Rank): bool =
-  rank in {Spammer, Troll, Banned}
+  rank in bannedRanks
 
 when defined(js):
   include karax/prelude
@@ -63,7 +66,7 @@ when defined(js):
   proc renderUserRank*(user: User): VNode =
     result = buildHtml():
       case user.rank
-      of Spammer, Troll, Banned:
+      of bannedRanks:
         italic(class="fas fa-eye-ban",
                title="User is banned")
       of Rank.User, EmailUnconfirmed:

--- a/src/setup_nimforum.nim
+++ b/src/setup_nimforum.nim
@@ -123,7 +123,7 @@ proc initialiseDb(admin: tuple[username, password, email: string],
 
   # Create some test data for development
   if isTest or isDev:
-    for rank in Spammer..Moderator:
+    for rank in AutoSpammer..Moderator:
       let rankLower = toLowerAscii($rank)
       let user = (username: $rankLower,
                   password: $rankLower,


### PR DESCRIPTION
This adds a check to https://stopforumspam.com whenever a `Moderated` user tries to post a new topic. I checked this approach against all new users from 2025 and it got about 2/3 spammers with zero false positives.

We could also look into automatically reporting users we mark as spammers back to the database, but this requires a bit more setup.

Also created a new rank `AutoSpammer` which is applied to users banned in this way, this will allow us to see how many users are marked as spammers this way.

Since it only applies to `Moderated` users if someone is falsely marked as a spammer we can simply mark them as `User` and it won't trigger the check.