### PR TITLE
update docker functionality

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,18 @@
-FROM nimlang/nim:1.6.4-ubuntu
+FROM nimlang/nim:2.2.4-ubuntu-regular
 
 RUN apt-get update -yqq \
     && apt-get install -y --no-install-recommends \
                libsass-dev \
                sqlite3 \
+               libpcre3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY . /app
+
+# add /app as safe.directory
+RUN git config --global --add safe.directory /app
 
 # install dependencies
 RUN nimble install -Y

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   forum:
     build:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,15 +5,15 @@ set -eu
 git submodule update --init --recursive
 
 # setup
-nimble c -d:release src/setup_nimforum.nim
+nim c -d:release src/setup_nimforum.nim
 ./src/setup_nimforum --dev
 
 # build frontend
-nimble c -r src/buildcss
-nimble js -d:release src/frontend/forum.nim
+nim c -r src/buildcss
+nim js -d:release src/frontend/forum.nim
 mkdir -p public/js
 cp src/frontend/forum.js public/js/forum.js
 
 # build backend
-nimble c src/forum.nim
+nim c -mm:refc src/forum.nim
 ./src/forum


### PR DESCRIPTION
This updates building nimforum using docker. Specifically it updates the `Dockerfile` to use `2.2.4-ubuntu-regular`, and the entrypoint to use `nim c` instead of `nimble c`. Finally, it adds `--mm:refc` when building `src/forum` because ORC causes a segfault inside the docker.