### PR TITLE
Switch `bcrypt` for `bcryptrocks` for better OS compatibility.

### DIFF
--- a/nimforum.nimble
+++ b/nimforum.nimble
@@ -15,7 +15,7 @@ skipExt = @["nim"]
 requires "nim >= 1.0.6"
 requires "httpbeast >= 0.4.0"
 requires "jester#405be2e"
-requires "bcrypt#440c5676ff6"
+requires "bcryptrocks >= 0.1.1"
 requires "hmac#9c61ebe2fd134cf97"
 requires "recaptcha#d06488e"
 requires "sass#649e0701fa5c"


### PR DESCRIPTION
The bcrypt library used by nimforum has known problems with OS compatibility (runvnc/bcryptnim#3), this doesn't just affect Windows users but it also affects the Alpine docker feature PR in nim-lang/nimforum#389

A couple months ago, I decided to make a bcrypt library wrapping over the [`crypt_blowfish`](https://github.com/openwall/crypt_blowfish) library written by Solar Designer, this is the `bcryptrocks` library.
This PR replaces the bcrypt library with the new one.

I've taken care to make sure this new bcrypt library generates the same hashes as the previous one (you can see the [test file here](https://codeberg.org/penguinite/bcryptrocks/src/branch/main/tests/test1.nim#L56)), this also does fix the weird build errors in the Docker PR (see [this PR](https://codeberg.org/penguinite/bcryptrocks/src/branch/main/tests/test1.nim#L56) with a build log using the bcryptrocks library), merging this would finally bring nimforum to Windows users, and to Alpine (and other musl-based) systems.
